### PR TITLE
[fix][xs]: Remove / from header names to avoid datahub.io error and update csv data

### DIFF
--- a/datapackage.json
+++ b/datapackage.json
@@ -1,11 +1,11 @@
 {
-  "bytes": 463524,
-  "count_of_rows": 8955,
-  "hash": "2e74b71787289aac912b647688893625",
+  "bytes": 545058,
+  "count_of_rows": 10350,
+  "hash": "305ff4220fa6ad6a26fea43b4faed91d",
   "profile": "data-package",
   "resources": [
     {
-      "bytes": 463524,
+      "bytes": 545058,
       "dialect": {
         "caseSensitiveHeader": false,
         "delimiter": ",",
@@ -17,7 +17,7 @@
       },
       "encoding": "utf-8",
       "format": "csv",
-      "hash": "88df9ccb75f4858ce93bc6607a9fefec",
+      "hash": "9b195200cbf74b876f3119136058c6b2",
       "name": "time-series-19-covid-combined",
       "path": "time-series-19-covid-combined.csv",
       "profile": "tabular-data-resource",
@@ -25,12 +25,12 @@
         "fields": [
           {
             "format": "default",
-            "name": "Province/State",
+            "name": "Province",
             "type": "string"
           },
           {
             "format": "default",
-            "name": "Country/Region",
+            "name": "Country",
             "type": "string"
           },
           {

--- a/process.py
+++ b/process.py
@@ -1,4 +1,4 @@
-from dataflows import Flow, load, unpivot, find_replace, set_type, dump_to_path, update_resource, join, add_computed_field, delete_fields
+from dataflows import Flow, load, unpivot, find_replace, set_type, dump_to_path, update_resource, join, add_computed_field, delete_fields, select_fields
 
 BASE_URL = 'https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/'
 CONFIRMED = 'time_series_19-covid-Confirmed.csv'
@@ -55,7 +55,18 @@ Flow(
         operation='format',
         with_='{Case}'
       ),
-      delete_fields(['Case']),
+      add_computed_field(
+        target={'name': 'Country', 'type': 'string'},
+        operation='format',
+        with_='{Country/Region}'
+      ),
+      add_computed_field(
+        target={'name': 'Province', 'type': 'string'},
+        operation='format',
+        with_='{Province/State}'
+      ),
+      delete_fields(['Case', 'Country/Region', 'Province/State']),
       update_resource('time_series_19-covid-Deaths', name='time-series-19-covid-combined', path='time-series-19-covid-combined.csv'),
+      select_fields(['Province', 'Country', 'Lat', 'Long', 'Date', 'Confirmed', 'Recovered', 'Deaths']),
       dump_to_path()
 ).results()[0]

--- a/time-series-19-covid-combined.csv
+++ b/time-series-19-covid-combined.csv
@@ -1,4 +1,4 @@
-Province/State,Country/Region,Lat,Long,Date,Confirmed,Recovered,Deaths
+Province,Country,Lat,Long,Date,Confirmed,Recovered,Deaths
 Anhui,Mainland China,31.8257,117.2264,2020-01-22,1,0,0
 Anhui,Mainland China,31.8257,117.2264,2020-01-23,9,0,0
 Anhui,Mainland China,31.8257,117.2264,2020-01-24,15,0,0
@@ -44,6 +44,7 @@ Anhui,Mainland China,31.8257,117.2264,2020-03-03,990,936,6
 Anhui,Mainland China,31.8257,117.2264,2020-03-04,990,956,6
 Anhui,Mainland China,31.8257,117.2264,2020-03-05,990,970,6
 Anhui,Mainland China,31.8257,117.2264,2020-03-06,990,979,6
+Anhui,Mainland China,31.8257,117.2264,2020-03-07,990,979,6
 Beijing,Mainland China,40.1824,116.4142,2020-01-22,14,0,0
 Beijing,Mainland China,40.1824,116.4142,2020-01-23,22,0,0
 Beijing,Mainland China,40.1824,116.4142,2020-01-24,36,1,0
@@ -89,6 +90,7 @@ Beijing,Mainland China,40.1824,116.4142,2020-03-03,414,288,8
 Beijing,Mainland China,40.1824,116.4142,2020-03-04,418,297,8
 Beijing,Mainland China,40.1824,116.4142,2020-03-05,418,297,8
 Beijing,Mainland China,40.1824,116.4142,2020-03-06,422,299,8
+Beijing,Mainland China,40.1824,116.4142,2020-03-07,426,303,8
 Chongqing,Mainland China,30.0572,107.874,2020-01-22,6,0,0
 Chongqing,Mainland China,30.0572,107.874,2020-01-23,9,0,0
 Chongqing,Mainland China,30.0572,107.874,2020-01-24,27,0,0
@@ -134,6 +136,7 @@ Chongqing,Mainland China,30.0572,107.874,2020-03-03,576,490,6
 Chongqing,Mainland China,30.0572,107.874,2020-03-04,576,502,6
 Chongqing,Mainland China,30.0572,107.874,2020-03-05,576,512,6
 Chongqing,Mainland China,30.0572,107.874,2020-03-06,576,513,6
+Chongqing,Mainland China,30.0572,107.874,2020-03-07,576,526,6
 Fujian,Mainland China,26.0789,117.9874,2020-01-22,1,0,0
 Fujian,Mainland China,26.0789,117.9874,2020-01-23,5,0,0
 Fujian,Mainland China,26.0789,117.9874,2020-01-24,10,0,0
@@ -179,6 +182,7 @@ Fujian,Mainland China,26.0789,117.9874,2020-03-03,296,260,1
 Fujian,Mainland China,26.0789,117.9874,2020-03-04,296,270,1
 Fujian,Mainland China,26.0789,117.9874,2020-03-05,296,277,1
 Fujian,Mainland China,26.0789,117.9874,2020-03-06,296,284,1
+Fujian,Mainland China,26.0789,117.9874,2020-03-07,296,295,1
 Gansu,Mainland China,36.0611,103.8343,2020-01-22,0,0,0
 Gansu,Mainland China,36.0611,103.8343,2020-01-23,2,0,0
 Gansu,Mainland China,36.0611,103.8343,2020-01-24,2,0,0
@@ -224,6 +228,7 @@ Gansu,Mainland China,36.0611,103.8343,2020-03-03,91,86,2
 Gansu,Mainland China,36.0611,103.8343,2020-03-04,91,87,2
 Gansu,Mainland China,36.0611,103.8343,2020-03-05,102,87,2
 Gansu,Mainland China,36.0611,103.8343,2020-03-06,119,87,2
+Gansu,Mainland China,36.0611,103.8343,2020-03-07,120,87,2
 Guangdong,Mainland China,23.3417,113.4244,2020-01-22,26,0,0
 Guangdong,Mainland China,23.3417,113.4244,2020-01-23,32,2,0
 Guangdong,Mainland China,23.3417,113.4244,2020-01-24,53,2,0
@@ -269,6 +274,7 @@ Guangdong,Mainland China,23.3417,113.4244,2020-03-03,1350,1101,7
 Guangdong,Mainland China,23.3417,113.4244,2020-03-04,1350,1133,7
 Guangdong,Mainland China,23.3417,113.4244,2020-03-05,1351,1181,7
 Guangdong,Mainland China,23.3417,113.4244,2020-03-06,1352,1216,7
+Guangdong,Mainland China,23.3417,113.4244,2020-03-07,1352,1237,7
 Guangxi,Mainland China,23.8298,108.7881,2020-01-22,2,0,0
 Guangxi,Mainland China,23.8298,108.7881,2020-01-23,5,0,0
 Guangxi,Mainland China,23.8298,108.7881,2020-01-24,23,0,0
@@ -314,6 +320,7 @@ Guangxi,Mainland China,23.8298,108.7881,2020-03-03,252,202,2
 Guangxi,Mainland China,23.8298,108.7881,2020-03-04,252,210,2
 Guangxi,Mainland China,23.8298,108.7881,2020-03-05,252,214,2
 Guangxi,Mainland China,23.8298,108.7881,2020-03-06,252,217,2
+Guangxi,Mainland China,23.8298,108.7881,2020-03-07,252,218,2
 Guizhou,Mainland China,26.8154,106.8748,2020-01-22,1,0,0
 Guizhou,Mainland China,26.8154,106.8748,2020-01-23,3,0,0
 Guizhou,Mainland China,26.8154,106.8748,2020-01-24,3,0,0
@@ -359,6 +366,7 @@ Guizhou,Mainland China,26.8154,106.8748,2020-03-03,146,114,2
 Guizhou,Mainland China,26.8154,106.8748,2020-03-04,146,114,2
 Guizhou,Mainland China,26.8154,106.8748,2020-03-05,146,114,2
 Guizhou,Mainland China,26.8154,106.8748,2020-03-06,146,114,2
+Guizhou,Mainland China,26.8154,106.8748,2020-03-07,146,115,2
 Hainan,Mainland China,19.1959,109.7453,2020-01-22,4,0,0
 Hainan,Mainland China,19.1959,109.7453,2020-01-23,5,0,0
 Hainan,Mainland China,19.1959,109.7453,2020-01-24,8,0,0
@@ -404,6 +412,7 @@ Hainan,Mainland China,19.1959,109.7453,2020-03-03,168,155,5
 Hainan,Mainland China,19.1959,109.7453,2020-03-04,168,158,5
 Hainan,Mainland China,19.1959,109.7453,2020-03-05,168,158,6
 Hainan,Mainland China,19.1959,109.7453,2020-03-06,168,158,6
+Hainan,Mainland China,19.1959,109.7453,2020-03-07,168,158,6
 Hebei,Mainland China,38.0428,114.5149,2020-01-22,1,0,0
 Hebei,Mainland China,38.0428,114.5149,2020-01-23,1,0,1
 Hebei,Mainland China,38.0428,114.5149,2020-01-24,2,0,1
@@ -449,6 +458,7 @@ Hebei,Mainland China,38.0428,114.5149,2020-03-03,318,300,6
 Hebei,Mainland China,38.0428,114.5149,2020-03-04,318,301,6
 Hebei,Mainland China,38.0428,114.5149,2020-03-05,318,304,6
 Hebei,Mainland China,38.0428,114.5149,2020-03-06,318,305,6
+Hebei,Mainland China,38.0428,114.5149,2020-03-07,318,307,6
 Heilongjiang,Mainland China,47.862,127.7615,2020-01-22,0,0,0
 Heilongjiang,Mainland China,47.862,127.7615,2020-01-23,2,0,0
 Heilongjiang,Mainland China,47.862,127.7615,2020-01-24,4,0,1
@@ -494,6 +504,7 @@ Heilongjiang,Mainland China,47.862,127.7615,2020-03-03,480,366,13
 Heilongjiang,Mainland China,47.862,127.7615,2020-03-04,480,373,13
 Heilongjiang,Mainland China,47.862,127.7615,2020-03-05,481,379,13
 Heilongjiang,Mainland China,47.862,127.7615,2020-03-06,481,396,13
+Heilongjiang,Mainland China,47.862,127.7615,2020-03-07,481,403,13
 Henan,Mainland China,33.88202,113.614,2020-01-22,5,0,0
 Henan,Mainland China,33.88202,113.614,2020-01-23,5,0,0
 Henan,Mainland China,33.88202,113.614,2020-01-24,9,0,0
@@ -539,6 +550,7 @@ Henan,Mainland China,33.88202,113.614,2020-03-03,1272,1231,22
 Henan,Mainland China,33.88202,113.614,2020-03-04,1272,1234,22
 Henan,Mainland China,33.88202,113.614,2020-03-05,1272,1239,22
 Henan,Mainland China,33.88202,113.614,2020-03-06,1272,1244,22
+Henan,Mainland China,33.88202,113.614,2020-03-07,1272,1244,22
 Hubei,Mainland China,30.9756,112.2707,2020-01-22,444,28,17
 Hubei,Mainland China,30.9756,112.2707,2020-01-23,444,28,17
 Hubei,Mainland China,30.9756,112.2707,2020-01-24,549,31,24
@@ -584,6 +596,7 @@ Hubei,Mainland China,30.9756,112.2707,2020-03-03,67217,36208,2835
 Hubei,Mainland China,30.9756,112.2707,2020-03-04,67332,38557,2871
 Hubei,Mainland China,30.9756,112.2707,2020-03-05,67466,40592,2902
 Hubei,Mainland China,30.9756,112.2707,2020-03-06,67592,42033,2931
+Hubei,Mainland China,30.9756,112.2707,2020-03-07,67666,43500,2959
 Hunan,Mainland China,27.6104,111.7088,2020-01-22,4,0,0
 Hunan,Mainland China,27.6104,111.7088,2020-01-23,9,0,0
 Hunan,Mainland China,27.6104,111.7088,2020-01-24,24,0,0
@@ -629,6 +642,7 @@ Hunan,Mainland China,27.6104,111.7088,2020-03-03,1018,906,4
 Hunan,Mainland China,27.6104,111.7088,2020-03-04,1018,916,4
 Hunan,Mainland China,27.6104,111.7088,2020-03-05,1018,938,4
 Hunan,Mainland China,27.6104,111.7088,2020-03-06,1018,955,4
+Hunan,Mainland China,27.6104,111.7088,2020-03-07,1018,960,4
 Inner Mongolia,Mainland China,44.0935,113.9448,2020-01-22,0,0,0
 Inner Mongolia,Mainland China,44.0935,113.9448,2020-01-23,0,0,0
 Inner Mongolia,Mainland China,44.0935,113.9448,2020-01-24,1,0,0
@@ -674,6 +688,7 @@ Inner Mongolia,Mainland China,44.0935,113.9448,2020-03-03,75,59,1
 Inner Mongolia,Mainland China,44.0935,113.9448,2020-03-04,75,63,1
 Inner Mongolia,Mainland China,44.0935,113.9448,2020-03-05,75,65,1
 Inner Mongolia,Mainland China,44.0935,113.9448,2020-03-06,75,65,1
+Inner Mongolia,Mainland China,44.0935,113.9448,2020-03-07,75,67,1
 Jiangsu,Mainland China,32.9711,119.455,2020-01-22,1,0,0
 Jiangsu,Mainland China,32.9711,119.455,2020-01-23,5,0,0
 Jiangsu,Mainland China,32.9711,119.455,2020-01-24,9,0,0
@@ -719,6 +734,7 @@ Jiangsu,Mainland China,32.9711,119.455,2020-03-03,631,562,0
 Jiangsu,Mainland China,32.9711,119.455,2020-03-04,631,577,0
 Jiangsu,Mainland China,32.9711,119.455,2020-03-05,631,583,0
 Jiangsu,Mainland China,32.9711,119.455,2020-03-06,631,594,0
+Jiangsu,Mainland China,32.9711,119.455,2020-03-07,631,606,0
 Jiangxi,Mainland China,27.614,115.7221,2020-01-22,2,0,0
 Jiangxi,Mainland China,27.614,115.7221,2020-01-23,7,0,0
 Jiangxi,Mainland China,27.614,115.7221,2020-01-24,18,0,0
@@ -764,6 +780,7 @@ Jiangxi,Mainland China,27.614,115.7221,2020-03-03,935,870,1
 Jiangxi,Mainland China,27.614,115.7221,2020-03-04,935,884,1
 Jiangxi,Mainland China,27.614,115.7221,2020-03-05,935,901,1
 Jiangxi,Mainland China,27.614,115.7221,2020-03-06,935,909,1
+Jiangxi,Mainland China,27.614,115.7221,2020-03-07,935,916,1
 Jilin,Mainland China,43.6661,126.1923,2020-01-22,0,0,0
 Jilin,Mainland China,43.6661,126.1923,2020-01-23,1,0,0
 Jilin,Mainland China,43.6661,126.1923,2020-01-24,3,0,0
@@ -809,6 +826,7 @@ Jilin,Mainland China,43.6661,126.1923,2020-03-03,93,83,1
 Jilin,Mainland China,43.6661,126.1923,2020-03-04,93,86,1
 Jilin,Mainland China,43.6661,126.1923,2020-03-05,93,88,1
 Jilin,Mainland China,43.6661,126.1923,2020-03-06,93,90,1
+Jilin,Mainland China,43.6661,126.1923,2020-03-07,93,90,1
 Liaoning,Mainland China,41.2956,122.6085,2020-01-22,2,0,0
 Liaoning,Mainland China,41.2956,122.6085,2020-01-23,3,0,0
 Liaoning,Mainland China,41.2956,122.6085,2020-01-24,4,0,0
@@ -854,6 +872,7 @@ Liaoning,Mainland China,41.2956,122.6085,2020-03-03,125,106,1
 Liaoning,Mainland China,41.2956,122.6085,2020-03-04,125,106,1
 Liaoning,Mainland China,41.2956,122.6085,2020-03-05,125,106,1
 Liaoning,Mainland China,41.2956,122.6085,2020-03-06,125,106,1
+Liaoning,Mainland China,41.2956,122.6085,2020-03-07,125,107,1
 Ningxia,Mainland China,37.2692,106.1655,2020-01-22,1,0,0
 Ningxia,Mainland China,37.2692,106.1655,2020-01-23,1,0,0
 Ningxia,Mainland China,37.2692,106.1655,2020-01-24,2,0,0
@@ -899,6 +918,7 @@ Ningxia,Mainland China,37.2692,106.1655,2020-03-03,74,69,0
 Ningxia,Mainland China,37.2692,106.1655,2020-03-04,75,69,0
 Ningxia,Mainland China,37.2692,106.1655,2020-03-05,75,69,0
 Ningxia,Mainland China,37.2692,106.1655,2020-03-06,75,71,0
+Ningxia,Mainland China,37.2692,106.1655,2020-03-07,75,71,0
 Qinghai,Mainland China,35.7452,95.9956,2020-01-22,0,0,0
 Qinghai,Mainland China,35.7452,95.9956,2020-01-23,0,0,0
 Qinghai,Mainland China,35.7452,95.9956,2020-01-24,0,0,0
@@ -944,6 +964,7 @@ Qinghai,Mainland China,35.7452,95.9956,2020-03-03,18,18,0
 Qinghai,Mainland China,35.7452,95.9956,2020-03-04,18,18,0
 Qinghai,Mainland China,35.7452,95.9956,2020-03-05,18,18,0
 Qinghai,Mainland China,35.7452,95.9956,2020-03-06,18,18,0
+Qinghai,Mainland China,35.7452,95.9956,2020-03-07,18,18,0
 Shaanxi,Mainland China,35.1917,108.8701,2020-01-22,0,0,0
 Shaanxi,Mainland China,35.1917,108.8701,2020-01-23,3,0,0
 Shaanxi,Mainland China,35.1917,108.8701,2020-01-24,5,0,0
@@ -989,6 +1010,7 @@ Shaanxi,Mainland China,35.1917,108.8701,2020-03-03,245,216,1
 Shaanxi,Mainland China,35.1917,108.8701,2020-03-04,245,223,1
 Shaanxi,Mainland China,35.1917,108.8701,2020-03-05,245,224,1
 Shaanxi,Mainland China,35.1917,108.8701,2020-03-06,245,226,1
+Shaanxi,Mainland China,35.1917,108.8701,2020-03-07,245,226,1
 Shandong,Mainland China,36.3427,118.1498,2020-01-22,2,0,0
 Shandong,Mainland China,36.3427,118.1498,2020-01-23,6,0,0
 Shandong,Mainland China,36.3427,118.1498,2020-01-24,15,0,0
@@ -1034,6 +1056,7 @@ Shandong,Mainland China,36.3427,118.1498,2020-03-03,758,511,6
 Shandong,Mainland China,36.3427,118.1498,2020-03-04,758,516,6
 Shandong,Mainland China,36.3427,118.1498,2020-03-05,758,578,6
 Shandong,Mainland China,36.3427,118.1498,2020-03-06,758,618,6
+Shandong,Mainland China,36.3427,118.1498,2020-03-07,758,627,6
 Shanghai,Mainland China,31.202,121.4491,2020-01-22,9,0,0
 Shanghai,Mainland China,31.202,121.4491,2020-01-23,16,0,0
 Shanghai,Mainland China,31.202,121.4491,2020-01-24,20,1,0
@@ -1079,6 +1102,7 @@ Shanghai,Mainland China,31.202,121.4491,2020-03-03,338,294,3
 Shanghai,Mainland China,31.202,121.4491,2020-03-04,338,298,3
 Shanghai,Mainland China,31.202,121.4491,2020-03-05,339,303,3
 Shanghai,Mainland China,31.202,121.4491,2020-03-06,342,306,3
+Shanghai,Mainland China,31.202,121.4491,2020-03-07,342,313,3
 Shanxi,Mainland China,37.5777,112.2922,2020-01-22,1,0,0
 Shanxi,Mainland China,37.5777,112.2922,2020-01-23,1,0,0
 Shanxi,Mainland China,37.5777,112.2922,2020-01-24,1,0,0
@@ -1124,6 +1148,7 @@ Shanxi,Mainland China,37.5777,112.2922,2020-03-03,133,124,0
 Shanxi,Mainland China,37.5777,112.2922,2020-03-04,133,124,0
 Shanxi,Mainland China,37.5777,112.2922,2020-03-05,133,126,0
 Shanxi,Mainland China,37.5777,112.2922,2020-03-06,133,126,0
+Shanxi,Mainland China,37.5777,112.2922,2020-03-07,133,126,0
 Sichuan,Mainland China,30.6171,102.7103,2020-01-22,5,0,0
 Sichuan,Mainland China,30.6171,102.7103,2020-01-23,8,0,0
 Sichuan,Mainland China,30.6171,102.7103,2020-01-24,15,0,0
@@ -1169,6 +1194,7 @@ Sichuan,Mainland China,30.6171,102.7103,2020-03-03,538,394,3
 Sichuan,Mainland China,30.6171,102.7103,2020-03-04,538,406,3
 Sichuan,Mainland China,30.6171,102.7103,2020-03-05,539,425,3
 Sichuan,Mainland China,30.6171,102.7103,2020-03-06,539,442,3
+Sichuan,Mainland China,30.6171,102.7103,2020-03-07,539,454,3
 Tianjin,Mainland China,39.3054,117.323,2020-01-22,4,0,0
 Tianjin,Mainland China,39.3054,117.323,2020-01-23,4,0,0
 Tianjin,Mainland China,39.3054,117.323,2020-01-24,8,0,0
@@ -1214,6 +1240,7 @@ Tianjin,Mainland China,39.3054,117.323,2020-03-03,136,124,3
 Tianjin,Mainland China,39.3054,117.323,2020-03-04,136,124,3
 Tianjin,Mainland China,39.3054,117.323,2020-03-05,136,128,3
 Tianjin,Mainland China,39.3054,117.323,2020-03-06,136,128,3
+Tianjin,Mainland China,39.3054,117.323,2020-03-07,136,128,3
 Tibet,Mainland China,31.6927,88.0924,2020-01-22,0,0,0
 Tibet,Mainland China,31.6927,88.0924,2020-01-23,0,0,0
 Tibet,Mainland China,31.6927,88.0924,2020-01-24,0,0,0
@@ -1259,6 +1286,7 @@ Tibet,Mainland China,31.6927,88.0924,2020-03-03,1,1,0
 Tibet,Mainland China,31.6927,88.0924,2020-03-04,1,1,0
 Tibet,Mainland China,31.6927,88.0924,2020-03-05,1,1,0
 Tibet,Mainland China,31.6927,88.0924,2020-03-06,1,1,0
+Tibet,Mainland China,31.6927,88.0924,2020-03-07,1,1,0
 Xinjiang,Mainland China,41.1129,85.2401,2020-01-22,0,0,0
 Xinjiang,Mainland China,41.1129,85.2401,2020-01-23,2,0,0
 Xinjiang,Mainland China,41.1129,85.2401,2020-01-24,2,0,0
@@ -1304,6 +1332,7 @@ Xinjiang,Mainland China,41.1129,85.2401,2020-03-03,76,68,3
 Xinjiang,Mainland China,41.1129,85.2401,2020-03-04,76,69,3
 Xinjiang,Mainland China,41.1129,85.2401,2020-03-05,76,70,3
 Xinjiang,Mainland China,41.1129,85.2401,2020-03-06,76,71,3
+Xinjiang,Mainland China,41.1129,85.2401,2020-03-07,76,72,3
 Yunnan,Mainland China,24.974,101.487,2020-01-22,1,0,0
 Yunnan,Mainland China,24.974,101.487,2020-01-23,2,0,0
 Yunnan,Mainland China,24.974,101.487,2020-01-24,5,0,0
@@ -1349,6 +1378,7 @@ Yunnan,Mainland China,24.974,101.487,2020-03-03,174,169,2
 Yunnan,Mainland China,24.974,101.487,2020-03-04,174,169,2
 Yunnan,Mainland China,24.974,101.487,2020-03-05,174,169,2
 Yunnan,Mainland China,24.974,101.487,2020-03-06,174,170,2
+Yunnan,Mainland China,24.974,101.487,2020-03-07,174,170,2
 Zhejiang,Mainland China,29.1832,120.0934,2020-01-22,10,0,0
 Zhejiang,Mainland China,29.1832,120.0934,2020-01-23,27,0,0
 Zhejiang,Mainland China,29.1832,120.0934,2020-01-24,43,1,0
@@ -1394,6 +1424,7 @@ Zhejiang,Mainland China,29.1832,120.0934,2020-03-03,1213,1093,1
 Zhejiang,Mainland China,29.1832,120.0934,2020-03-04,1213,1114,1
 Zhejiang,Mainland China,29.1832,120.0934,2020-03-05,1215,1124,1
 Zhejiang,Mainland China,29.1832,120.0934,2020-03-06,1215,1147,1
+Zhejiang,Mainland China,29.1832,120.0934,2020-03-07,1215,1154,1
 ,Thailand,15,101,2020-01-22,2,0,0
 ,Thailand,15,101,2020-01-23,3,0,0
 ,Thailand,15,101,2020-01-24,5,0,0
@@ -1439,6 +1470,7 @@ Zhejiang,Mainland China,29.1832,120.0934,2020-03-06,1215,1147,1
 ,Thailand,15,101,2020-03-04,43,31,1
 ,Thailand,15,101,2020-03-05,47,31,1
 ,Thailand,15,101,2020-03-06,48,31,1
+,Thailand,15,101,2020-03-07,50,31,1
 ,Japan,36,138,2020-01-22,2,0,0
 ,Japan,36,138,2020-01-23,3,0,0
 ,Japan,36,138,2020-01-24,5,0,0
@@ -1484,6 +1516,7 @@ Zhejiang,Mainland China,29.1832,120.0934,2020-03-06,1215,1147,1
 ,Japan,36,138,2020-03-04,43,31,6
 ,Japan,36,138,2020-03-05,47,31,6
 ,Japan,36,138,2020-03-06,48,31,6
+,Japan,36,138,2020-03-07,50,31,6
 ,South Korea,36,128,2020-01-22,2,0,0
 ,South Korea,36,128,2020-01-23,3,0,0
 ,South Korea,36,128,2020-01-24,5,0,0
@@ -1529,6 +1562,7 @@ Zhejiang,Mainland China,29.1832,120.0934,2020-03-06,1215,1147,1
 ,South Korea,36,128,2020-03-04,43,31,35
 ,South Korea,36,128,2020-03-05,47,31,35
 ,South Korea,36,128,2020-03-06,48,31,42
+,South Korea,36,128,2020-03-07,50,31,44
 Taiwan,Taiwan,23.7,121,2020-01-22,1,0,0
 Taiwan,Taiwan,23.7,121,2020-01-23,1,0,0
 Taiwan,Taiwan,23.7,121,2020-01-24,3,0,0
@@ -1574,6 +1608,7 @@ Taiwan,Taiwan,23.7,121,2020-03-03,42,12,1
 Taiwan,Taiwan,23.7,121,2020-03-04,42,12,1
 Taiwan,Taiwan,23.7,121,2020-03-05,44,12,1
 Taiwan,Taiwan,23.7,121,2020-03-06,45,12,1
+Taiwan,Taiwan,23.7,121,2020-03-07,45,12,1
 "King County, WA",US,47.6062,-122.3321,2020-01-22,1,0,0
 "King County, WA",US,47.6062,-122.3321,2020-01-23,1,0,0
 "King County, WA",US,47.6062,-122.3321,2020-01-24,1,0,0
@@ -1619,6 +1654,7 @@ Taiwan,Taiwan,23.7,121,2020-03-06,45,12,1
 "King County, WA",US,47.6062,-122.3321,2020-03-04,31,1,9
 "King County, WA",US,47.6062,-122.3321,2020-03-05,51,1,10
 "King County, WA",US,47.6062,-122.3321,2020-03-06,58,1,12
+"King County, WA",US,47.6062,-122.3321,2020-03-07,71,1,15
 "Cook County, IL",US,41.7377,-87.6976,2020-01-22,0,0,0
 "Cook County, IL",US,41.7377,-87.6976,2020-01-23,0,0,0
 "Cook County, IL",US,41.7377,-87.6976,2020-01-24,1,0,0
@@ -1664,51 +1700,7 @@ Taiwan,Taiwan,23.7,121,2020-03-06,45,12,1
 "Cook County, IL",US,41.7377,-87.6976,2020-03-04,4,2,0
 "Cook County, IL",US,41.7377,-87.6976,2020-03-05,5,2,0
 "Cook County, IL",US,41.7377,-87.6976,2020-03-06,5,2,0
-"Tempe, AZ",US,33.4255,-111.94,2020-01-22,0,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-01-23,0,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-01-24,0,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-01-25,0,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-01-26,1,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-01-27,1,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-01-28,1,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-01-29,1,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-01-30,1,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-01-31,1,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-02-01,1,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-02-02,1,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-02-03,1,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-02-04,1,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-02-05,1,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-02-06,1,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-02-07,1,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-02-08,1,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-02-09,1,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-02-10,1,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-02-11,1,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-02-12,1,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-02-13,1,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-02-14,1,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-02-15,1,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-02-16,1,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-02-17,1,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-02-18,1,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-02-19,1,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-02-20,1,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-02-21,1,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-02-22,1,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-02-23,1,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-02-24,1,0,0
-"Tempe, AZ",US,33.4255,-111.94,2020-02-25,1,1,0
-"Tempe, AZ",US,33.4255,-111.94,2020-02-26,1,1,0
-"Tempe, AZ",US,33.4255,-111.94,2020-02-27,1,1,0
-"Tempe, AZ",US,33.4255,-111.94,2020-02-28,1,1,0
-"Tempe, AZ",US,33.4255,-111.94,2020-02-29,1,1,0
-"Tempe, AZ",US,33.4255,-111.94,2020-03-01,1,1,0
-"Tempe, AZ",US,33.4255,-111.94,2020-03-02,1,1,0
-"Tempe, AZ",US,33.4255,-111.94,2020-03-03,1,1,0
-"Tempe, AZ",US,33.4255,-111.94,2020-03-04,1,1,0
-"Tempe, AZ",US,33.4255,-111.94,2020-03-05,1,1,0
-"Tempe, AZ",US,33.4255,-111.94,2020-03-06,1,1,0
+"Cook County, IL",US,41.7377,-87.6976,2020-03-07,6,2,0
 Macau,Macau,22.1667,113.55,2020-01-22,1,0,0
 Macau,Macau,22.1667,113.55,2020-01-23,2,0,0
 Macau,Macau,22.1667,113.55,2020-01-24,2,0,0
@@ -1754,6 +1746,7 @@ Macau,Macau,22.1667,113.55,2020-03-03,10,9,0
 Macau,Macau,22.1667,113.55,2020-03-04,10,9,0
 Macau,Macau,22.1667,113.55,2020-03-05,10,9,0
 Macau,Macau,22.1667,113.55,2020-03-06,10,10,0
+Macau,Macau,22.1667,113.55,2020-03-07,10,10,0
 Hong Kong,Hong Kong,22.3,114.2,2020-01-22,0,0,0
 Hong Kong,Hong Kong,22.3,114.2,2020-01-23,2,0,0
 Hong Kong,Hong Kong,22.3,114.2,2020-01-24,2,0,0
@@ -1799,6 +1792,7 @@ Hong Kong,Hong Kong,22.3,114.2,2020-03-03,100,37,2
 Hong Kong,Hong Kong,22.3,114.2,2020-03-04,105,37,2
 Hong Kong,Hong Kong,22.3,114.2,2020-03-05,105,43,2
 Hong Kong,Hong Kong,22.3,114.2,2020-03-06,107,46,2
+Hong Kong,Hong Kong,22.3,114.2,2020-03-07,108,51,2
 ,Singapore,1.2833,103.8333,2020-01-22,2,0,0
 ,Singapore,1.2833,103.8333,2020-01-23,3,0,0
 ,Singapore,1.2833,103.8333,2020-01-24,5,0,0
@@ -1844,6 +1838,7 @@ Hong Kong,Hong Kong,22.3,114.2,2020-03-06,107,46,2
 ,Singapore,1.2833,103.8333,2020-03-04,43,31,0
 ,Singapore,1.2833,103.8333,2020-03-05,47,31,0
 ,Singapore,1.2833,103.8333,2020-03-06,48,31,0
+,Singapore,1.2833,103.8333,2020-03-07,50,31,0
 ,Vietnam,16,108,2020-01-22,2,0,0
 ,Vietnam,16,108,2020-01-23,3,0,0
 ,Vietnam,16,108,2020-01-24,5,0,0
@@ -1889,6 +1884,7 @@ Hong Kong,Hong Kong,22.3,114.2,2020-03-06,107,46,2
 ,Vietnam,16,108,2020-03-04,43,31,0
 ,Vietnam,16,108,2020-03-05,47,31,0
 ,Vietnam,16,108,2020-03-06,48,31,0
+,Vietnam,16,108,2020-03-07,50,31,0
 ,France,47,2,2020-01-22,2,0,0
 ,France,47,2,2020-01-23,3,0,0
 ,France,47,2,2020-01-24,5,0,0
@@ -1934,6 +1930,7 @@ Hong Kong,Hong Kong,22.3,114.2,2020-03-06,107,46,2
 ,France,47,2,2020-03-04,43,31,4
 ,France,47,2,2020-03-05,47,31,6
 ,France,47,2,2020-03-06,48,31,9
+,France,47,2,2020-03-07,50,31,11
 ,Nepal,28.1667,84.25,2020-01-22,2,0,0
 ,Nepal,28.1667,84.25,2020-01-23,3,0,0
 ,Nepal,28.1667,84.25,2020-01-24,5,0,0
@@ -1979,6 +1976,7 @@ Hong Kong,Hong Kong,22.3,114.2,2020-03-06,107,46,2
 ,Nepal,28.1667,84.25,2020-03-04,43,31,0
 ,Nepal,28.1667,84.25,2020-03-05,47,31,0
 ,Nepal,28.1667,84.25,2020-03-06,48,31,0
+,Nepal,28.1667,84.25,2020-03-07,50,31,0
 ,Malaysia,2.5,112.5,2020-01-22,2,0,0
 ,Malaysia,2.5,112.5,2020-01-23,3,0,0
 ,Malaysia,2.5,112.5,2020-01-24,5,0,0
@@ -2024,6 +2022,7 @@ Hong Kong,Hong Kong,22.3,114.2,2020-03-06,107,46,2
 ,Malaysia,2.5,112.5,2020-03-04,43,31,0
 ,Malaysia,2.5,112.5,2020-03-05,47,31,0
 ,Malaysia,2.5,112.5,2020-03-06,48,31,0
+,Malaysia,2.5,112.5,2020-03-07,50,31,0
 "Toronto, ON",Canada,43.6532,-79.3832,2020-01-22,0,0,0
 "Toronto, ON",Canada,43.6532,-79.3832,2020-01-23,0,0,0
 "Toronto, ON",Canada,43.6532,-79.3832,2020-01-24,0,0,0
@@ -2069,6 +2068,7 @@ Hong Kong,Hong Kong,22.3,114.2,2020-03-06,107,46,2
 "Toronto, ON",Canada,43.6532,-79.3832,2020-03-04,19,2,0
 "Toronto, ON",Canada,43.6532,-79.3832,2020-03-05,21,2,0
 "Toronto, ON",Canada,43.6532,-79.3832,2020-03-06,24,2,0
+"Toronto, ON",Canada,43.6532,-79.3832,2020-03-07,27,3,0
 British Columbia,Canada,49.2827,-123.1207,2020-01-22,0,0,0
 British Columbia,Canada,49.2827,-123.1207,2020-01-23,0,0,0
 British Columbia,Canada,49.2827,-123.1207,2020-01-24,0,0,0
@@ -2114,6 +2114,7 @@ British Columbia,Canada,49.2827,-123.1207,2020-03-03,9,3,0
 British Columbia,Canada,49.2827,-123.1207,2020-03-04,12,3,0
 British Columbia,Canada,49.2827,-123.1207,2020-03-05,13,3,0
 British Columbia,Canada,49.2827,-123.1207,2020-03-06,21,3,0
+British Columbia,Canada,49.2827,-123.1207,2020-03-07,21,4,0
 "Los Angeles, CA",US,34.0522,-118.2437,2020-01-22,0,0,0
 "Los Angeles, CA",US,34.0522,-118.2437,2020-01-23,0,0,0
 "Los Angeles, CA",US,34.0522,-118.2437,2020-01-24,0,0,0
@@ -2159,6 +2160,7 @@ British Columbia,Canada,49.2827,-123.1207,2020-03-06,21,3,0
 "Los Angeles, CA",US,34.0522,-118.2437,2020-03-04,7,0,0
 "Los Angeles, CA",US,34.0522,-118.2437,2020-03-05,11,0,0
 "Los Angeles, CA",US,34.0522,-118.2437,2020-03-06,13,0,0
+"Los Angeles, CA",US,34.0522,-118.2437,2020-03-07,14,0,0
 New South Wales,Australia,-33.8688,151.2093,2020-01-22,0,0,0
 New South Wales,Australia,-33.8688,151.2093,2020-01-23,0,0,0
 New South Wales,Australia,-33.8688,151.2093,2020-01-24,0,0,0
@@ -2204,6 +2206,7 @@ New South Wales,Australia,-33.8688,151.2093,2020-03-03,13,4,0
 New South Wales,Australia,-33.8688,151.2093,2020-03-04,22,4,1
 New South Wales,Australia,-33.8688,151.2093,2020-03-05,22,4,1
 New South Wales,Australia,-33.8688,151.2093,2020-03-06,26,4,1
+New South Wales,Australia,-33.8688,151.2093,2020-03-07,28,4,1
 Victoria,Australia,-37.8136,144.9631,2020-01-22,0,0,0
 Victoria,Australia,-37.8136,144.9631,2020-01-23,0,0,0
 Victoria,Australia,-37.8136,144.9631,2020-01-24,0,0,0
@@ -2249,6 +2252,7 @@ Victoria,Australia,-37.8136,144.9631,2020-03-03,9,4,0
 Victoria,Australia,-37.8136,144.9631,2020-03-04,10,4,0
 Victoria,Australia,-37.8136,144.9631,2020-03-05,10,7,0
 Victoria,Australia,-37.8136,144.9631,2020-03-06,10,7,0
+Victoria,Australia,-37.8136,144.9631,2020-03-07,11,7,0
 Queensland,Australia,-28.0167,153.4,2020-01-22,0,0,0
 Queensland,Australia,-28.0167,153.4,2020-01-23,0,0,0
 Queensland,Australia,-28.0167,153.4,2020-01-24,0,0,0
@@ -2294,6 +2298,7 @@ Queensland,Australia,-28.0167,153.4,2020-03-03,11,1,0
 Queensland,Australia,-28.0167,153.4,2020-03-04,11,1,0
 Queensland,Australia,-28.0167,153.4,2020-03-05,13,8,0
 Queensland,Australia,-28.0167,153.4,2020-03-06,13,8,0
+Queensland,Australia,-28.0167,153.4,2020-03-07,13,8,0
 ,Cambodia,11.55,104.9167,2020-01-22,2,0,0
 ,Cambodia,11.55,104.9167,2020-01-23,3,0,0
 ,Cambodia,11.55,104.9167,2020-01-24,5,0,0
@@ -2339,6 +2344,7 @@ Queensland,Australia,-28.0167,153.4,2020-03-06,13,8,0
 ,Cambodia,11.55,104.9167,2020-03-04,43,31,0
 ,Cambodia,11.55,104.9167,2020-03-05,47,31,0
 ,Cambodia,11.55,104.9167,2020-03-06,48,31,0
+,Cambodia,11.55,104.9167,2020-03-07,50,31,0
 ,Sri Lanka,7,81,2020-01-22,2,0,0
 ,Sri Lanka,7,81,2020-01-23,3,0,0
 ,Sri Lanka,7,81,2020-01-24,5,0,0
@@ -2384,6 +2390,7 @@ Queensland,Australia,-28.0167,153.4,2020-03-06,13,8,0
 ,Sri Lanka,7,81,2020-03-04,43,31,0
 ,Sri Lanka,7,81,2020-03-05,47,31,0
 ,Sri Lanka,7,81,2020-03-06,48,31,0
+,Sri Lanka,7,81,2020-03-07,50,31,0
 ,Germany,51,9,2020-01-22,2,0,0
 ,Germany,51,9,2020-01-23,3,0,0
 ,Germany,51,9,2020-01-24,5,0,0
@@ -2429,6 +2436,7 @@ Queensland,Australia,-28.0167,153.4,2020-03-06,13,8,0
 ,Germany,51,9,2020-03-04,43,31,0
 ,Germany,51,9,2020-03-05,47,31,0
 ,Germany,51,9,2020-03-06,48,31,0
+,Germany,51,9,2020-03-07,50,31,0
 ,Finland,64,26,2020-01-22,2,0,0
 ,Finland,64,26,2020-01-23,3,0,0
 ,Finland,64,26,2020-01-24,5,0,0
@@ -2474,6 +2482,7 @@ Queensland,Australia,-28.0167,153.4,2020-03-06,13,8,0
 ,Finland,64,26,2020-03-04,43,31,0
 ,Finland,64,26,2020-03-05,47,31,0
 ,Finland,64,26,2020-03-06,48,31,0
+,Finland,64,26,2020-03-07,50,31,0
 ,United Arab Emirates,24,54,2020-01-22,2,0,0
 ,United Arab Emirates,24,54,2020-01-23,3,0,0
 ,United Arab Emirates,24,54,2020-01-24,5,0,0
@@ -2519,6 +2528,7 @@ Queensland,Australia,-28.0167,153.4,2020-03-06,13,8,0
 ,United Arab Emirates,24,54,2020-03-04,43,31,0
 ,United Arab Emirates,24,54,2020-03-05,47,31,0
 ,United Arab Emirates,24,54,2020-03-06,48,31,0
+,United Arab Emirates,24,54,2020-03-07,50,31,0
 ,Philippines,13,122,2020-01-22,2,0,0
 ,Philippines,13,122,2020-01-23,3,0,0
 ,Philippines,13,122,2020-01-24,5,0,0
@@ -2564,6 +2574,7 @@ Queensland,Australia,-28.0167,153.4,2020-03-06,13,8,0
 ,Philippines,13,122,2020-03-04,43,31,1
 ,Philippines,13,122,2020-03-05,47,31,1
 ,Philippines,13,122,2020-03-06,48,31,1
+,Philippines,13,122,2020-03-07,50,31,1
 ,India,21,78,2020-01-22,2,0,0
 ,India,21,78,2020-01-23,3,0,0
 ,India,21,78,2020-01-24,5,0,0
@@ -2609,6 +2620,7 @@ Queensland,Australia,-28.0167,153.4,2020-03-06,13,8,0
 ,India,21,78,2020-03-04,43,31,0
 ,India,21,78,2020-03-05,47,31,0
 ,India,21,78,2020-03-06,48,31,0
+,India,21,78,2020-03-07,50,31,0
 "London, ON",Canada,42.9849,-81.2453,2020-01-22,0,0,0
 "London, ON",Canada,42.9849,-81.2453,2020-01-23,0,0,0
 "London, ON",Canada,42.9849,-81.2453,2020-01-24,0,0,0
@@ -2654,6 +2666,7 @@ Queensland,Australia,-28.0167,153.4,2020-03-06,13,8,0
 "London, ON",Canada,42.9849,-81.2453,2020-03-04,1,1,0
 "London, ON",Canada,42.9849,-81.2453,2020-03-05,1,1,0
 "London, ON",Canada,42.9849,-81.2453,2020-03-06,1,1,0
+"London, ON",Canada,42.9849,-81.2453,2020-03-07,1,1,0
 ,Italy,43,12,2020-01-22,2,0,0
 ,Italy,43,12,2020-01-23,3,0,0
 ,Italy,43,12,2020-01-24,5,0,0
@@ -2699,6 +2712,7 @@ Queensland,Australia,-28.0167,153.4,2020-03-06,13,8,0
 ,Italy,43,12,2020-03-04,43,31,107
 ,Italy,43,12,2020-03-05,47,31,148
 ,Italy,43,12,2020-03-06,48,31,197
+,Italy,43,12,2020-03-07,50,31,233
 ,UK,55,-3,2020-01-22,2,0,0
 ,UK,55,-3,2020-01-23,3,0,0
 ,UK,55,-3,2020-01-24,5,0,0
@@ -2744,6 +2758,7 @@ Queensland,Australia,-28.0167,153.4,2020-03-06,13,8,0
 ,UK,55,-3,2020-03-04,43,31,0
 ,UK,55,-3,2020-03-05,47,31,1
 ,UK,55,-3,2020-03-06,48,31,2
+,UK,55,-3,2020-03-07,50,31,2
 ,Russia,60,90,2020-01-22,2,0,0
 ,Russia,60,90,2020-01-23,3,0,0
 ,Russia,60,90,2020-01-24,5,0,0
@@ -2789,6 +2804,7 @@ Queensland,Australia,-28.0167,153.4,2020-03-06,13,8,0
 ,Russia,60,90,2020-03-04,43,31,0
 ,Russia,60,90,2020-03-05,47,31,0
 ,Russia,60,90,2020-03-06,48,31,0
+,Russia,60,90,2020-03-07,50,31,0
 ,Sweden,63,16,2020-01-22,2,0,0
 ,Sweden,63,16,2020-01-23,3,0,0
 ,Sweden,63,16,2020-01-24,5,0,0
@@ -2834,51 +2850,7 @@ Queensland,Australia,-28.0167,153.4,2020-03-06,13,8,0
 ,Sweden,63,16,2020-03-04,43,31,0
 ,Sweden,63,16,2020-03-05,47,31,0
 ,Sweden,63,16,2020-03-06,48,31,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-01-22,0,0,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-01-23,0,0,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-01-24,0,0,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-01-25,0,0,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-01-26,0,0,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-01-27,0,0,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-01-28,0,0,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-01-29,0,0,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-01-30,0,0,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-01-31,1,0,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-02-01,1,0,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-02-02,1,0,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-02-03,2,0,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-02-04,2,0,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-02-05,2,0,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-02-06,2,0,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-02-07,2,0,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-02-08,2,0,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-02-09,2,0,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-02-10,2,0,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-02-11,2,0,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-02-12,2,0,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-02-13,2,0,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-02-14,2,0,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-02-15,2,0,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-02-16,2,0,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-02-17,2,0,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-02-18,2,0,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-02-19,2,0,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-02-20,2,0,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-02-21,2,1,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-02-22,2,1,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-02-23,2,1,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-02-24,2,1,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-02-25,2,1,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-02-26,2,1,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-02-27,2,1,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-02-28,2,1,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-02-29,3,1,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-03-01,3,1,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-03-02,9,1,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-03-03,11,1,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-03-04,11,1,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-03-05,20,1,0
-"Santa Clara, CA",US,37.3541,-121.9552,2020-03-06,20,1,0
+,Sweden,63,16,2020-03-07,50,31,0
 ,Spain,40,-4,2020-01-22,2,0,0
 ,Spain,40,-4,2020-01-23,3,0,0
 ,Spain,40,-4,2020-01-24,5,0,0
@@ -2924,6 +2896,7 @@ Queensland,Australia,-28.0167,153.4,2020-03-06,13,8,0
 ,Spain,40,-4,2020-03-04,43,31,2
 ,Spain,40,-4,2020-03-05,47,31,3
 ,Spain,40,-4,2020-03-06,48,31,5
+,Spain,40,-4,2020-03-07,50,31,10
 South Australia,Australia,-34.9285,138.6007,2020-01-22,0,0,0
 South Australia,Australia,-34.9285,138.6007,2020-01-23,0,0,0
 South Australia,Australia,-34.9285,138.6007,2020-01-24,0,0,0
@@ -2969,6 +2942,7 @@ South Australia,Australia,-34.9285,138.6007,2020-03-03,3,2,0
 South Australia,Australia,-34.9285,138.6007,2020-03-04,5,2,0
 South Australia,Australia,-34.9285,138.6007,2020-03-05,5,2,0
 South Australia,Australia,-34.9285,138.6007,2020-03-06,7,2,0
+South Australia,Australia,-34.9285,138.6007,2020-03-07,7,2,0
 "San Benito, CA",US,36.5761,-120.9876,2020-01-22,0,0,0
 "San Benito, CA",US,36.5761,-120.9876,2020-01-23,0,0,0
 "San Benito, CA",US,36.5761,-120.9876,2020-01-24,0,0,0
@@ -3014,6 +2988,7 @@ South Australia,Australia,-34.9285,138.6007,2020-03-06,7,2,0
 "San Benito, CA",US,36.5761,-120.9876,2020-03-04,2,0,0
 "San Benito, CA",US,36.5761,-120.9876,2020-03-05,2,0,0
 "San Benito, CA",US,36.5761,-120.9876,2020-03-06,2,0,0
+"San Benito, CA",US,36.5761,-120.9876,2020-03-07,2,0,0
 ,Belgium,50.8333,4,2020-01-22,2,0,0
 ,Belgium,50.8333,4,2020-01-23,3,0,0
 ,Belgium,50.8333,4,2020-01-24,5,0,0
@@ -3059,6 +3034,7 @@ South Australia,Australia,-34.9285,138.6007,2020-03-06,7,2,0
 ,Belgium,50.8333,4,2020-03-04,43,31,0
 ,Belgium,50.8333,4,2020-03-05,47,31,0
 ,Belgium,50.8333,4,2020-03-06,48,31,0
+,Belgium,50.8333,4,2020-03-07,50,31,0
 "Madison, WI",US,43.0731,-89.4012,2020-01-22,0,0,0
 "Madison, WI",US,43.0731,-89.4012,2020-01-23,0,0,0
 "Madison, WI",US,43.0731,-89.4012,2020-01-24,0,0,0
@@ -3104,6 +3080,7 @@ South Australia,Australia,-34.9285,138.6007,2020-03-06,7,2,0
 "Madison, WI",US,43.0731,-89.4012,2020-03-04,1,1,0
 "Madison, WI",US,43.0731,-89.4012,2020-03-05,1,1,0
 "Madison, WI",US,43.0731,-89.4012,2020-03-06,1,1,0
+"Madison, WI",US,43.0731,-89.4012,2020-03-07,1,1,0
 Diamond Princess cruise ship,Others,35.4437,139.638,2020-01-22,0,0,0
 Diamond Princess cruise ship,Others,35.4437,139.638,2020-01-23,0,0,0
 Diamond Princess cruise ship,Others,35.4437,139.638,2020-01-24,0,0,0
@@ -3149,6 +3126,7 @@ Diamond Princess cruise ship,Others,35.4437,139.638,2020-03-03,706,10,6
 Diamond Princess cruise ship,Others,35.4437,139.638,2020-03-04,706,10,6
 Diamond Princess cruise ship,Others,35.4437,139.638,2020-03-05,706,10,6
 Diamond Princess cruise ship,Others,35.4437,139.638,2020-03-06,696,40,6
+Diamond Princess cruise ship,Others,35.4437,139.638,2020-03-07,696,40,6
 "San Diego County, CA",US,32.7157,-117.1611,2020-01-22,0,0,0
 "San Diego County, CA",US,32.7157,-117.1611,2020-01-23,0,0,0
 "San Diego County, CA",US,32.7157,-117.1611,2020-01-24,0,0,0
@@ -3194,6 +3172,7 @@ Diamond Princess cruise ship,Others,35.4437,139.638,2020-03-06,696,40,6
 "San Diego County, CA",US,32.7157,-117.1611,2020-03-04,2,1,0
 "San Diego County, CA",US,32.7157,-117.1611,2020-03-05,3,1,0
 "San Diego County, CA",US,32.7157,-117.1611,2020-03-06,3,1,0
+"San Diego County, CA",US,32.7157,-117.1611,2020-03-07,3,1,0
 "San Antonio, TX",US,29.4241,-98.4936,2020-01-22,0,0,0
 "San Antonio, TX",US,29.4241,-98.4936,2020-01-23,0,0,0
 "San Antonio, TX",US,29.4241,-98.4936,2020-01-24,0,0,0
@@ -3239,6 +3218,7 @@ Diamond Princess cruise ship,Others,35.4437,139.638,2020-03-06,696,40,6
 "San Antonio, TX",US,29.4241,-98.4936,2020-03-04,1,0,0
 "San Antonio, TX",US,29.4241,-98.4936,2020-03-05,1,0,0
 "San Antonio, TX",US,29.4241,-98.4936,2020-03-06,1,0,0
+"San Antonio, TX",US,29.4241,-98.4936,2020-03-07,1,0,0
 ,Egypt,26,30,2020-01-22,2,0,0
 ,Egypt,26,30,2020-01-23,3,0,0
 ,Egypt,26,30,2020-01-24,5,0,0
@@ -3284,6 +3264,7 @@ Diamond Princess cruise ship,Others,35.4437,139.638,2020-03-06,696,40,6
 ,Egypt,26,30,2020-03-04,43,31,0
 ,Egypt,26,30,2020-03-05,47,31,0
 ,Egypt,26,30,2020-03-06,48,31,0
+,Egypt,26,30,2020-03-07,50,31,0
 ,Iran,32,53,2020-01-22,2,0,0
 ,Iran,32,53,2020-01-23,3,0,0
 ,Iran,32,53,2020-01-24,5,0,0
@@ -3329,6 +3310,7 @@ Diamond Princess cruise ship,Others,35.4437,139.638,2020-03-06,696,40,6
 ,Iran,32,53,2020-03-04,43,31,92
 ,Iran,32,53,2020-03-05,47,31,107
 ,Iran,32,53,2020-03-06,48,31,124
+,Iran,32,53,2020-03-07,50,31,145
 "Omaha, NE (From Diamond Princess)",US,41.2545,-95.9758,2020-01-22,0,0,0
 "Omaha, NE (From Diamond Princess)",US,41.2545,-95.9758,2020-01-23,0,0,0
 "Omaha, NE (From Diamond Princess)",US,41.2545,-95.9758,2020-01-24,0,0,0
@@ -3374,6 +3356,7 @@ Diamond Princess cruise ship,Others,35.4437,139.638,2020-03-06,696,40,6
 "Omaha, NE (From Diamond Princess)",US,41.2545,-95.9758,2020-03-04,0,0,0
 "Omaha, NE (From Diamond Princess)",US,41.2545,-95.9758,2020-03-05,0,0,0
 "Omaha, NE (From Diamond Princess)",US,41.2545,-95.9758,2020-03-06,0,0,0
+"Omaha, NE (From Diamond Princess)",US,41.2545,-95.9758,2020-03-07,0,0,0
 "Travis, CA (From Diamond Princess)",US,38.2721,-121.9399,2020-01-22,0,0,0
 "Travis, CA (From Diamond Princess)",US,38.2721,-121.9399,2020-01-23,0,0,0
 "Travis, CA (From Diamond Princess)",US,38.2721,-121.9399,2020-01-24,0,0,0
@@ -3419,6 +3402,7 @@ Diamond Princess cruise ship,Others,35.4437,139.638,2020-03-06,696,40,6
 "Travis, CA (From Diamond Princess)",US,38.2721,-121.9399,2020-03-04,0,0,0
 "Travis, CA (From Diamond Princess)",US,38.2721,-121.9399,2020-03-05,0,0,0
 "Travis, CA (From Diamond Princess)",US,38.2721,-121.9399,2020-03-06,0,0,0
+"Travis, CA (From Diamond Princess)",US,38.2721,-121.9399,2020-03-07,0,0,0
 From Diamond Princess,Australia,35.4437,139.638,2020-01-22,0,0,0
 From Diamond Princess,Australia,35.4437,139.638,2020-01-23,0,0,0
 From Diamond Princess,Australia,35.4437,139.638,2020-01-24,0,0,0
@@ -3464,6 +3448,7 @@ From Diamond Princess,Australia,35.4437,139.638,2020-03-03,0,0,0
 From Diamond Princess,Australia,35.4437,139.638,2020-03-04,0,0,0
 From Diamond Princess,Australia,35.4437,139.638,2020-03-05,0,0,0
 From Diamond Princess,Australia,35.4437,139.638,2020-03-06,0,0,0
+From Diamond Princess,Australia,35.4437,139.638,2020-03-07,0,0,0
 "Lackland, TX (From Diamond Princess)",US,29.3829,-98.6134,2020-01-22,0,0,0
 "Lackland, TX (From Diamond Princess)",US,29.3829,-98.6134,2020-01-23,0,0,0
 "Lackland, TX (From Diamond Princess)",US,29.3829,-98.6134,2020-01-24,0,0,0
@@ -3509,6 +3494,7 @@ From Diamond Princess,Australia,35.4437,139.638,2020-03-06,0,0,0
 "Lackland, TX (From Diamond Princess)",US,29.3829,-98.6134,2020-03-04,0,0,0
 "Lackland, TX (From Diamond Princess)",US,29.3829,-98.6134,2020-03-05,0,0,0
 "Lackland, TX (From Diamond Princess)",US,29.3829,-98.6134,2020-03-06,0,0,0
+"Lackland, TX (From Diamond Princess)",US,29.3829,-98.6134,2020-03-07,0,0,0
 ,Lebanon,33.8547,35.8623,2020-01-22,2,0,0
 ,Lebanon,33.8547,35.8623,2020-01-23,3,0,0
 ,Lebanon,33.8547,35.8623,2020-01-24,5,0,0
@@ -3554,6 +3540,7 @@ From Diamond Princess,Australia,35.4437,139.638,2020-03-06,0,0,0
 ,Lebanon,33.8547,35.8623,2020-03-04,43,31,0
 ,Lebanon,33.8547,35.8623,2020-03-05,47,31,0
 ,Lebanon,33.8547,35.8623,2020-03-06,48,31,0
+,Lebanon,33.8547,35.8623,2020-03-07,50,31,0
 "Humboldt County, CA",US,40.745,-123.8695,2020-01-22,0,0,0
 "Humboldt County, CA",US,40.745,-123.8695,2020-01-23,0,0,0
 "Humboldt County, CA",US,40.745,-123.8695,2020-01-24,0,0,0
@@ -3599,6 +3586,7 @@ From Diamond Princess,Australia,35.4437,139.638,2020-03-06,0,0,0
 "Humboldt County, CA",US,40.745,-123.8695,2020-03-04,1,0,0
 "Humboldt County, CA",US,40.745,-123.8695,2020-03-05,1,0,0
 "Humboldt County, CA",US,40.745,-123.8695,2020-03-06,1,0,0
+"Humboldt County, CA",US,40.745,-123.8695,2020-03-07,1,0,0
 "Sacramento County, CA",US,38.4747,-121.3542,2020-01-22,0,0,0
 "Sacramento County, CA",US,38.4747,-121.3542,2020-01-23,0,0,0
 "Sacramento County, CA",US,38.4747,-121.3542,2020-01-24,0,0,0
@@ -3644,6 +3632,7 @@ From Diamond Princess,Australia,35.4437,139.638,2020-03-06,0,0,0
 "Sacramento County, CA",US,38.4747,-121.3542,2020-03-04,2,0,0
 "Sacramento County, CA",US,38.4747,-121.3542,2020-03-05,2,0,0
 "Sacramento County, CA",US,38.4747,-121.3542,2020-03-06,2,0,0
+"Sacramento County, CA",US,38.4747,-121.3542,2020-03-07,2,0,0
 ,Iraq,33,44,2020-01-22,2,0,0
 ,Iraq,33,44,2020-01-23,3,0,0
 ,Iraq,33,44,2020-01-24,5,0,0
@@ -3689,6 +3678,7 @@ From Diamond Princess,Australia,35.4437,139.638,2020-03-06,0,0,0
 ,Iraq,33,44,2020-03-04,43,31,2
 ,Iraq,33,44,2020-03-05,47,31,2
 ,Iraq,33,44,2020-03-06,48,31,3
+,Iraq,33,44,2020-03-07,50,31,4
 Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-01-22,0,0,0
 Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-01-23,0,0,0
 Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-01-24,0,0,0
@@ -3734,6 +3724,7 @@ Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-03,45,0,0
 Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-04,45,0,0
 Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-05,45,0,0
 Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-06,45,0,0
+Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-07,45,0,0
 ,Oman,21,57,2020-01-22,2,0,0
 ,Oman,21,57,2020-01-23,3,0,0
 ,Oman,21,57,2020-01-24,5,0,0
@@ -3779,6 +3770,7 @@ Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-06,45,0,0
 ,Oman,21,57,2020-03-04,43,31,0
 ,Oman,21,57,2020-03-05,47,31,0
 ,Oman,21,57,2020-03-06,48,31,0
+,Oman,21,57,2020-03-07,50,31,0
 ,Afghanistan,33,65,2020-01-22,2,0,0
 ,Afghanistan,33,65,2020-01-23,3,0,0
 ,Afghanistan,33,65,2020-01-24,5,0,0
@@ -3824,6 +3816,7 @@ Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-06,45,0,0
 ,Afghanistan,33,65,2020-03-04,43,31,0
 ,Afghanistan,33,65,2020-03-05,47,31,0
 ,Afghanistan,33,65,2020-03-06,48,31,0
+,Afghanistan,33,65,2020-03-07,50,31,0
 ,Bahrain,26.0275,50.55,2020-01-22,2,0,0
 ,Bahrain,26.0275,50.55,2020-01-23,3,0,0
 ,Bahrain,26.0275,50.55,2020-01-24,5,0,0
@@ -3869,6 +3862,7 @@ Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-06,45,0,0
 ,Bahrain,26.0275,50.55,2020-03-04,43,31,0
 ,Bahrain,26.0275,50.55,2020-03-05,47,31,0
 ,Bahrain,26.0275,50.55,2020-03-06,48,31,0
+,Bahrain,26.0275,50.55,2020-03-07,50,31,0
 ,Kuwait,29.5,47.75,2020-01-22,2,0,0
 ,Kuwait,29.5,47.75,2020-01-23,3,0,0
 ,Kuwait,29.5,47.75,2020-01-24,5,0,0
@@ -3914,6 +3908,7 @@ Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-06,45,0,0
 ,Kuwait,29.5,47.75,2020-03-04,43,31,0
 ,Kuwait,29.5,47.75,2020-03-05,47,31,0
 ,Kuwait,29.5,47.75,2020-03-06,48,31,0
+,Kuwait,29.5,47.75,2020-03-07,50,31,0
 ,Algeria,28.0339,1.6596,2020-01-22,2,0,0
 ,Algeria,28.0339,1.6596,2020-01-23,3,0,0
 ,Algeria,28.0339,1.6596,2020-01-24,5,0,0
@@ -3959,6 +3954,7 @@ Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-06,45,0,0
 ,Algeria,28.0339,1.6596,2020-03-04,43,31,0
 ,Algeria,28.0339,1.6596,2020-03-05,47,31,0
 ,Algeria,28.0339,1.6596,2020-03-06,48,31,0
+,Algeria,28.0339,1.6596,2020-03-07,50,31,0
 ,Croatia,45.1,15.2,2020-01-22,2,0,0
 ,Croatia,45.1,15.2,2020-01-23,3,0,0
 ,Croatia,45.1,15.2,2020-01-24,5,0,0
@@ -4004,6 +4000,7 @@ Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-06,45,0,0
 ,Croatia,45.1,15.2,2020-03-04,43,31,0
 ,Croatia,45.1,15.2,2020-03-05,47,31,0
 ,Croatia,45.1,15.2,2020-03-06,48,31,0
+,Croatia,45.1,15.2,2020-03-07,50,31,0
 ,Switzerland,46.8182,8.2275,2020-01-22,2,0,0
 ,Switzerland,46.8182,8.2275,2020-01-23,3,0,0
 ,Switzerland,46.8182,8.2275,2020-01-24,5,0,0
@@ -4049,6 +4046,7 @@ Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-06,45,0,0
 ,Switzerland,46.8182,8.2275,2020-03-04,43,31,0
 ,Switzerland,46.8182,8.2275,2020-03-05,47,31,1
 ,Switzerland,46.8182,8.2275,2020-03-06,48,31,1
+,Switzerland,46.8182,8.2275,2020-03-07,50,31,1
 ,Austria,47.5162,14.5501,2020-01-22,2,0,0
 ,Austria,47.5162,14.5501,2020-01-23,3,0,0
 ,Austria,47.5162,14.5501,2020-01-24,5,0,0
@@ -4094,6 +4092,7 @@ Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-06,45,0,0
 ,Austria,47.5162,14.5501,2020-03-04,43,31,0
 ,Austria,47.5162,14.5501,2020-03-05,47,31,0
 ,Austria,47.5162,14.5501,2020-03-06,48,31,0
+,Austria,47.5162,14.5501,2020-03-07,50,31,0
 ,Israel,31,35,2020-01-22,2,0,0
 ,Israel,31,35,2020-01-23,3,0,0
 ,Israel,31,35,2020-01-24,5,0,0
@@ -4139,6 +4138,7 @@ Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-06,45,0,0
 ,Israel,31,35,2020-03-04,43,31,0
 ,Israel,31,35,2020-03-05,47,31,0
 ,Israel,31,35,2020-03-06,48,31,0
+,Israel,31,35,2020-03-07,50,31,0
 ,Pakistan,30.3753,69.3451,2020-01-22,2,0,0
 ,Pakistan,30.3753,69.3451,2020-01-23,3,0,0
 ,Pakistan,30.3753,69.3451,2020-01-24,5,0,0
@@ -4184,6 +4184,7 @@ Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-06,45,0,0
 ,Pakistan,30.3753,69.3451,2020-03-04,43,31,0
 ,Pakistan,30.3753,69.3451,2020-03-05,47,31,0
 ,Pakistan,30.3753,69.3451,2020-03-06,48,31,0
+,Pakistan,30.3753,69.3451,2020-03-07,50,31,0
 ,Brazil,-14.235,-51.9253,2020-01-22,2,0,0
 ,Brazil,-14.235,-51.9253,2020-01-23,3,0,0
 ,Brazil,-14.235,-51.9253,2020-01-24,5,0,0
@@ -4229,6 +4230,7 @@ Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-06,45,0,0
 ,Brazil,-14.235,-51.9253,2020-03-04,43,31,0
 ,Brazil,-14.235,-51.9253,2020-03-05,47,31,0
 ,Brazil,-14.235,-51.9253,2020-03-06,48,31,0
+,Brazil,-14.235,-51.9253,2020-03-07,50,31,0
 ,Georgia,42.3154,43.3569,2020-01-22,2,0,0
 ,Georgia,42.3154,43.3569,2020-01-23,3,0,0
 ,Georgia,42.3154,43.3569,2020-01-24,5,0,0
@@ -4274,6 +4276,7 @@ Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-06,45,0,0
 ,Georgia,42.3154,43.3569,2020-03-04,43,31,0
 ,Georgia,42.3154,43.3569,2020-03-05,47,31,0
 ,Georgia,42.3154,43.3569,2020-03-06,48,31,0
+,Georgia,42.3154,43.3569,2020-03-07,50,31,0
 ,Greece,39.0742,21.8243,2020-01-22,2,0,0
 ,Greece,39.0742,21.8243,2020-01-23,3,0,0
 ,Greece,39.0742,21.8243,2020-01-24,5,0,0
@@ -4319,6 +4322,7 @@ Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-06,45,0,0
 ,Greece,39.0742,21.8243,2020-03-04,43,31,0
 ,Greece,39.0742,21.8243,2020-03-05,47,31,0
 ,Greece,39.0742,21.8243,2020-03-06,48,31,0
+,Greece,39.0742,21.8243,2020-03-07,50,31,0
 ,North Macedonia,41.6086,21.7453,2020-01-22,2,0,0
 ,North Macedonia,41.6086,21.7453,2020-01-23,3,0,0
 ,North Macedonia,41.6086,21.7453,2020-01-24,5,0,0
@@ -4364,6 +4368,7 @@ Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-06,45,0,0
 ,North Macedonia,41.6086,21.7453,2020-03-04,43,31,0
 ,North Macedonia,41.6086,21.7453,2020-03-05,47,31,0
 ,North Macedonia,41.6086,21.7453,2020-03-06,48,31,0
+,North Macedonia,41.6086,21.7453,2020-03-07,50,31,0
 ,Norway,60.472,8.4689,2020-01-22,2,0,0
 ,Norway,60.472,8.4689,2020-01-23,3,0,0
 ,Norway,60.472,8.4689,2020-01-24,5,0,0
@@ -4409,6 +4414,7 @@ Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-06,45,0,0
 ,Norway,60.472,8.4689,2020-03-04,43,31,0
 ,Norway,60.472,8.4689,2020-03-05,47,31,0
 ,Norway,60.472,8.4689,2020-03-06,48,31,0
+,Norway,60.472,8.4689,2020-03-07,50,31,0
 ,Romania,45.9432,24.9668,2020-01-22,2,0,0
 ,Romania,45.9432,24.9668,2020-01-23,3,0,0
 ,Romania,45.9432,24.9668,2020-01-24,5,0,0
@@ -4454,6 +4460,7 @@ Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-06,45,0,0
 ,Romania,45.9432,24.9668,2020-03-04,43,31,0
 ,Romania,45.9432,24.9668,2020-03-05,47,31,0
 ,Romania,45.9432,24.9668,2020-03-06,48,31,0
+,Romania,45.9432,24.9668,2020-03-07,50,31,0
 ,Denmark,56.2639,9.5018,2020-01-22,2,0,0
 ,Denmark,56.2639,9.5018,2020-01-23,3,0,0
 ,Denmark,56.2639,9.5018,2020-01-24,5,0,0
@@ -4499,6 +4506,7 @@ Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-06,45,0,0
 ,Denmark,56.2639,9.5018,2020-03-04,43,31,0
 ,Denmark,56.2639,9.5018,2020-03-05,47,31,0
 ,Denmark,56.2639,9.5018,2020-03-06,48,31,0
+,Denmark,56.2639,9.5018,2020-03-07,50,31,0
 ,Estonia,58.5953,25.0136,2020-01-22,2,0,0
 ,Estonia,58.5953,25.0136,2020-01-23,3,0,0
 ,Estonia,58.5953,25.0136,2020-01-24,5,0,0
@@ -4544,6 +4552,7 @@ Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-06,45,0,0
 ,Estonia,58.5953,25.0136,2020-03-04,43,31,0
 ,Estonia,58.5953,25.0136,2020-03-05,47,31,0
 ,Estonia,58.5953,25.0136,2020-03-06,48,31,0
+,Estonia,58.5953,25.0136,2020-03-07,50,31,0
 ,Netherlands,52.1326,5.2913,2020-01-22,2,0,0
 ,Netherlands,52.1326,5.2913,2020-01-23,3,0,0
 ,Netherlands,52.1326,5.2913,2020-01-24,5,0,0
@@ -4589,6 +4598,7 @@ Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-06,45,0,0
 ,Netherlands,52.1326,5.2913,2020-03-04,43,31,0
 ,Netherlands,52.1326,5.2913,2020-03-05,47,31,0
 ,Netherlands,52.1326,5.2913,2020-03-06,48,31,1
+,Netherlands,52.1326,5.2913,2020-03-07,50,31,1
 ,San Marino,43.9424,12.4578,2020-01-22,2,0,0
 ,San Marino,43.9424,12.4578,2020-01-23,3,0,0
 ,San Marino,43.9424,12.4578,2020-01-24,5,0,0
@@ -4634,6 +4644,7 @@ Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-06,45,0,0
 ,San Marino,43.9424,12.4578,2020-03-04,43,31,1
 ,San Marino,43.9424,12.4578,2020-03-05,47,31,1
 ,San Marino,43.9424,12.4578,2020-03-06,48,31,1
+,San Marino,43.9424,12.4578,2020-03-07,50,31,1
 ,Belarus,53.7098,27.9534,2020-01-22,2,0,0
 ,Belarus,53.7098,27.9534,2020-01-23,3,0,0
 ,Belarus,53.7098,27.9534,2020-01-24,5,0,0
@@ -4679,6 +4690,7 @@ Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-06,45,0,0
 ,Belarus,53.7098,27.9534,2020-03-04,43,31,0
 ,Belarus,53.7098,27.9534,2020-03-05,47,31,0
 ,Belarus,53.7098,27.9534,2020-03-06,48,31,0
+,Belarus,53.7098,27.9534,2020-03-07,50,31,0
 "Montreal, QC",Canada,45.5017,-73.5673,2020-01-22,0,0,0
 "Montreal, QC",Canada,45.5017,-73.5673,2020-01-23,0,0,0
 "Montreal, QC",Canada,45.5017,-73.5673,2020-01-24,0,0,0
@@ -4724,6 +4736,7 @@ Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-06,45,0,0
 "Montreal, QC",Canada,45.5017,-73.5673,2020-03-04,1,0,0
 "Montreal, QC",Canada,45.5017,-73.5673,2020-03-05,2,0,0
 "Montreal, QC",Canada,45.5017,-73.5673,2020-03-06,2,0,0
+"Montreal, QC",Canada,45.5017,-73.5673,2020-03-07,3,0,0
 ,Iceland,64.9631,-19.0208,2020-01-22,2,0,0
 ,Iceland,64.9631,-19.0208,2020-01-23,3,0,0
 ,Iceland,64.9631,-19.0208,2020-01-24,5,0,0
@@ -4769,6 +4782,7 @@ Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-06,45,0,0
 ,Iceland,64.9631,-19.0208,2020-03-04,43,31,0
 ,Iceland,64.9631,-19.0208,2020-03-05,47,31,0
 ,Iceland,64.9631,-19.0208,2020-03-06,48,31,0
+,Iceland,64.9631,-19.0208,2020-03-07,50,31,0
 ,Lithuania,55.1694,23.8813,2020-01-22,2,0,0
 ,Lithuania,55.1694,23.8813,2020-01-23,3,0,0
 ,Lithuania,55.1694,23.8813,2020-01-24,5,0,0
@@ -4814,6 +4828,7 @@ Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-06,45,0,0
 ,Lithuania,55.1694,23.8813,2020-03-04,43,31,0
 ,Lithuania,55.1694,23.8813,2020-03-05,47,31,0
 ,Lithuania,55.1694,23.8813,2020-03-06,48,31,0
+,Lithuania,55.1694,23.8813,2020-03-07,50,31,0
 ,Mexico,23.6345,-102.5528,2020-01-22,2,0,0
 ,Mexico,23.6345,-102.5528,2020-01-23,3,0,0
 ,Mexico,23.6345,-102.5528,2020-01-24,5,0,0
@@ -4859,6 +4874,7 @@ Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-06,45,0,0
 ,Mexico,23.6345,-102.5528,2020-03-04,43,31,0
 ,Mexico,23.6345,-102.5528,2020-03-05,47,31,0
 ,Mexico,23.6345,-102.5528,2020-03-06,48,31,0
+,Mexico,23.6345,-102.5528,2020-03-07,50,31,0
 ,New Zealand,-40.9006,174.886,2020-01-22,2,0,0
 ,New Zealand,-40.9006,174.886,2020-01-23,3,0,0
 ,New Zealand,-40.9006,174.886,2020-01-24,5,0,0
@@ -4904,6 +4920,7 @@ Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-06,45,0,0
 ,New Zealand,-40.9006,174.886,2020-03-04,43,31,0
 ,New Zealand,-40.9006,174.886,2020-03-05,47,31,0
 ,New Zealand,-40.9006,174.886,2020-03-06,48,31,0
+,New Zealand,-40.9006,174.886,2020-03-07,50,31,0
 ,Nigeria,9.082,8.6753,2020-01-22,2,0,0
 ,Nigeria,9.082,8.6753,2020-01-23,3,0,0
 ,Nigeria,9.082,8.6753,2020-01-24,5,0,0
@@ -4949,6 +4966,7 @@ Unassigned Location (From Diamond Princess),US,35.4437,139.638,2020-03-06,45,0,0
 ,Nigeria,9.082,8.6753,2020-03-04,43,31,0
 ,Nigeria,9.082,8.6753,2020-03-05,47,31,0
 ,Nigeria,9.082,8.6753,2020-03-06,48,31,0
+,Nigeria,9.082,8.6753,2020-03-07,50,31,0
 Western Australia,Australia,-31.9505,115.8605,2020-01-22,0,0,0
 Western Australia,Australia,-31.9505,115.8605,2020-01-23,0,0,0
 Western Australia,Australia,-31.9505,115.8605,2020-01-24,0,0,0
@@ -4994,6 +5012,7 @@ Western Australia,Australia,-31.9505,115.8605,2020-03-03,2,0,1
 Western Australia,Australia,-31.9505,115.8605,2020-03-04,2,0,1
 Western Australia,Australia,-31.9505,115.8605,2020-03-05,3,0,1
 Western Australia,Australia,-31.9505,115.8605,2020-03-06,3,0,1
+Western Australia,Australia,-31.9505,115.8605,2020-03-07,3,0,1
 ,Ireland,53.1424,-7.6921,2020-01-22,2,0,0
 ,Ireland,53.1424,-7.6921,2020-01-23,3,0,0
 ,Ireland,53.1424,-7.6921,2020-01-24,5,0,0
@@ -5039,6 +5058,7 @@ Western Australia,Australia,-31.9505,115.8605,2020-03-06,3,0,1
 ,Ireland,53.1424,-7.6921,2020-03-04,43,31,0
 ,Ireland,53.1424,-7.6921,2020-03-05,47,31,0
 ,Ireland,53.1424,-7.6921,2020-03-06,48,31,0
+,Ireland,53.1424,-7.6921,2020-03-07,50,31,0
 ,Luxembourg,49.8153,6.1296,2020-01-22,2,0,0
 ,Luxembourg,49.8153,6.1296,2020-01-23,3,0,0
 ,Luxembourg,49.8153,6.1296,2020-01-24,5,0,0
@@ -5084,6 +5104,7 @@ Western Australia,Australia,-31.9505,115.8605,2020-03-06,3,0,1
 ,Luxembourg,49.8153,6.1296,2020-03-04,43,31,0
 ,Luxembourg,49.8153,6.1296,2020-03-05,47,31,0
 ,Luxembourg,49.8153,6.1296,2020-03-06,48,31,0
+,Luxembourg,49.8153,6.1296,2020-03-07,50,31,0
 ,Monaco,43.7333,7.4167,2020-01-22,2,0,0
 ,Monaco,43.7333,7.4167,2020-01-23,3,0,0
 ,Monaco,43.7333,7.4167,2020-01-24,5,0,0
@@ -5129,6 +5150,7 @@ Western Australia,Australia,-31.9505,115.8605,2020-03-06,3,0,1
 ,Monaco,43.7333,7.4167,2020-03-04,43,31,0
 ,Monaco,43.7333,7.4167,2020-03-05,47,31,0
 ,Monaco,43.7333,7.4167,2020-03-06,48,31,0
+,Monaco,43.7333,7.4167,2020-03-07,50,31,0
 ,Qatar,25.3548,51.1839,2020-01-22,2,0,0
 ,Qatar,25.3548,51.1839,2020-01-23,3,0,0
 ,Qatar,25.3548,51.1839,2020-01-24,5,0,0
@@ -5174,6 +5196,7 @@ Western Australia,Australia,-31.9505,115.8605,2020-03-06,3,0,1
 ,Qatar,25.3548,51.1839,2020-03-04,43,31,0
 ,Qatar,25.3548,51.1839,2020-03-05,47,31,0
 ,Qatar,25.3548,51.1839,2020-03-06,48,31,0
+,Qatar,25.3548,51.1839,2020-03-07,50,31,0
 "Snohomish County, WA",US,48.033,-121.8339,2020-01-22,0,0,0
 "Snohomish County, WA",US,48.033,-121.8339,2020-01-23,0,0,0
 "Snohomish County, WA",US,48.033,-121.8339,2020-01-24,0,0,0
@@ -5219,6 +5242,7 @@ Western Australia,Australia,-31.9505,115.8605,2020-03-06,3,0,1
 "Snohomish County, WA",US,48.033,-121.8339,2020-03-04,8,0,1
 "Snohomish County, WA",US,48.033,-121.8339,2020-03-05,18,0,1
 "Snohomish County, WA",US,48.033,-121.8339,2020-03-06,19,0,1
+"Snohomish County, WA",US,48.033,-121.8339,2020-03-07,27,0,1
 ,Ecuador,-1.8312,-78.1834,2020-01-22,2,0,0
 ,Ecuador,-1.8312,-78.1834,2020-01-23,3,0,0
 ,Ecuador,-1.8312,-78.1834,2020-01-24,5,0,0
@@ -5264,6 +5288,7 @@ Western Australia,Australia,-31.9505,115.8605,2020-03-06,3,0,1
 ,Ecuador,-1.8312,-78.1834,2020-03-04,43,31,0
 ,Ecuador,-1.8312,-78.1834,2020-03-05,47,31,0
 ,Ecuador,-1.8312,-78.1834,2020-03-06,48,31,0
+,Ecuador,-1.8312,-78.1834,2020-03-07,50,31,0
 ,Azerbaijan,40.1431,47.5769,2020-01-22,2,0,0
 ,Azerbaijan,40.1431,47.5769,2020-01-23,3,0,0
 ,Azerbaijan,40.1431,47.5769,2020-01-24,5,0,0
@@ -5309,6 +5334,7 @@ Western Australia,Australia,-31.9505,115.8605,2020-03-06,3,0,1
 ,Azerbaijan,40.1431,47.5769,2020-03-04,43,31,0
 ,Azerbaijan,40.1431,47.5769,2020-03-05,47,31,0
 ,Azerbaijan,40.1431,47.5769,2020-03-06,48,31,0
+,Azerbaijan,40.1431,47.5769,2020-03-07,50,31,0
 ,Czech Republic,49.8175,15.473,2020-01-22,2,0,0
 ,Czech Republic,49.8175,15.473,2020-01-23,3,0,0
 ,Czech Republic,49.8175,15.473,2020-01-24,5,0,0
@@ -5354,6 +5380,7 @@ Western Australia,Australia,-31.9505,115.8605,2020-03-06,3,0,1
 ,Czech Republic,49.8175,15.473,2020-03-04,43,31,0
 ,Czech Republic,49.8175,15.473,2020-03-05,47,31,0
 ,Czech Republic,49.8175,15.473,2020-03-06,48,31,0
+,Czech Republic,49.8175,15.473,2020-03-07,50,31,0
 ,Armenia,40.0691,45.0382,2020-01-22,2,0,0
 ,Armenia,40.0691,45.0382,2020-01-23,3,0,0
 ,Armenia,40.0691,45.0382,2020-01-24,5,0,0
@@ -5399,6 +5426,7 @@ Western Australia,Australia,-31.9505,115.8605,2020-03-06,3,0,1
 ,Armenia,40.0691,45.0382,2020-03-04,43,31,0
 ,Armenia,40.0691,45.0382,2020-03-05,47,31,0
 ,Armenia,40.0691,45.0382,2020-03-06,48,31,0
+,Armenia,40.0691,45.0382,2020-03-07,50,31,0
 ,Dominican Republic,18.7357,-70.1627,2020-01-22,2,0,0
 ,Dominican Republic,18.7357,-70.1627,2020-01-23,3,0,0
 ,Dominican Republic,18.7357,-70.1627,2020-01-24,5,0,0
@@ -5444,51 +5472,7 @@ Western Australia,Australia,-31.9505,115.8605,2020-03-06,3,0,1
 ,Dominican Republic,18.7357,-70.1627,2020-03-04,43,31,0
 ,Dominican Republic,18.7357,-70.1627,2020-03-05,47,31,0
 ,Dominican Republic,18.7357,-70.1627,2020-03-06,48,31,0
-"Providence, RI",US,41.824,-71.4128,2020-01-22,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-01-23,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-01-24,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-01-25,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-01-26,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-01-27,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-01-28,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-01-29,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-01-30,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-01-31,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-02-01,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-02-02,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-02-03,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-02-04,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-02-05,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-02-06,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-02-07,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-02-08,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-02-09,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-02-10,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-02-11,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-02-12,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-02-13,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-02-14,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-02-15,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-02-16,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-02-17,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-02-18,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-02-19,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-02-20,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-02-21,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-02-22,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-02-23,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-02-24,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-02-25,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-02-26,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-02-27,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-02-28,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-02-29,0,0,0
-"Providence, RI",US,41.824,-71.4128,2020-03-01,1,0,0
-"Providence, RI",US,41.824,-71.4128,2020-03-02,2,0,0
-"Providence, RI",US,41.824,-71.4128,2020-03-03,2,0,0
-"Providence, RI",US,41.824,-71.4128,2020-03-04,2,0,0
-"Providence, RI",US,41.824,-71.4128,2020-03-05,2,0,0
-"Providence, RI",US,41.824,-71.4128,2020-03-06,2,0,0
+,Dominican Republic,18.7357,-70.1627,2020-03-07,50,31,0
 ,Indonesia,-0.7893,113.9213,2020-01-22,2,0,0
 ,Indonesia,-0.7893,113.9213,2020-01-23,3,0,0
 ,Indonesia,-0.7893,113.9213,2020-01-24,5,0,0
@@ -5534,6 +5518,7 @@ Western Australia,Australia,-31.9505,115.8605,2020-03-06,3,0,1
 ,Indonesia,-0.7893,113.9213,2020-03-04,43,31,0
 ,Indonesia,-0.7893,113.9213,2020-03-05,47,31,0
 ,Indonesia,-0.7893,113.9213,2020-03-06,48,31,0
+,Indonesia,-0.7893,113.9213,2020-03-07,50,31,0
 ,Portugal,39.3999,-8.2245,2020-01-22,2,0,0
 ,Portugal,39.3999,-8.2245,2020-01-23,3,0,0
 ,Portugal,39.3999,-8.2245,2020-01-24,5,0,0
@@ -5579,6 +5564,7 @@ Western Australia,Australia,-31.9505,115.8605,2020-03-06,3,0,1
 ,Portugal,39.3999,-8.2245,2020-03-04,43,31,0
 ,Portugal,39.3999,-8.2245,2020-03-05,47,31,0
 ,Portugal,39.3999,-8.2245,2020-03-06,48,31,0
+,Portugal,39.3999,-8.2245,2020-03-07,50,31,0
 ,Andorra,42.5063,1.5218,2020-01-22,2,0,0
 ,Andorra,42.5063,1.5218,2020-01-23,3,0,0
 ,Andorra,42.5063,1.5218,2020-01-24,5,0,0
@@ -5624,6 +5610,7 @@ Western Australia,Australia,-31.9505,115.8605,2020-03-06,3,0,1
 ,Andorra,42.5063,1.5218,2020-03-04,43,31,0
 ,Andorra,42.5063,1.5218,2020-03-05,47,31,0
 ,Andorra,42.5063,1.5218,2020-03-06,48,31,0
+,Andorra,42.5063,1.5218,2020-03-07,50,31,0
 Tasmania,Australia,-41.4545,145.9707,2020-01-22,0,0,0
 Tasmania,Australia,-41.4545,145.9707,2020-01-23,0,0,0
 Tasmania,Australia,-41.4545,145.9707,2020-01-24,0,0,0
@@ -5669,6 +5656,7 @@ Tasmania,Australia,-41.4545,145.9707,2020-03-03,1,0,0
 Tasmania,Australia,-41.4545,145.9707,2020-03-04,1,0,0
 Tasmania,Australia,-41.4545,145.9707,2020-03-05,1,0,0
 Tasmania,Australia,-41.4545,145.9707,2020-03-06,1,0,0
+Tasmania,Australia,-41.4545,145.9707,2020-03-07,1,0,0
 ,Latvia,56.8796,24.6032,2020-01-22,2,0,0
 ,Latvia,56.8796,24.6032,2020-01-23,3,0,0
 ,Latvia,56.8796,24.6032,2020-01-24,5,0,0
@@ -5714,6 +5702,7 @@ Tasmania,Australia,-41.4545,145.9707,2020-03-06,1,0,0
 ,Latvia,56.8796,24.6032,2020-03-04,43,31,0
 ,Latvia,56.8796,24.6032,2020-03-05,47,31,0
 ,Latvia,56.8796,24.6032,2020-03-06,48,31,0
+,Latvia,56.8796,24.6032,2020-03-07,50,31,0
 ,Morocco,31.7917,-7.0926,2020-01-22,2,0,0
 ,Morocco,31.7917,-7.0926,2020-01-23,3,0,0
 ,Morocco,31.7917,-7.0926,2020-01-24,5,0,0
@@ -5759,6 +5748,7 @@ Tasmania,Australia,-41.4545,145.9707,2020-03-06,1,0,0
 ,Morocco,31.7917,-7.0926,2020-03-04,43,31,0
 ,Morocco,31.7917,-7.0926,2020-03-05,47,31,0
 ,Morocco,31.7917,-7.0926,2020-03-06,48,31,0
+,Morocco,31.7917,-7.0926,2020-03-07,50,31,0
 ,Saudi Arabia,24,45,2020-01-22,2,0,0
 ,Saudi Arabia,24,45,2020-01-23,3,0,0
 ,Saudi Arabia,24,45,2020-01-24,5,0,0
@@ -5804,6 +5794,7 @@ Tasmania,Australia,-41.4545,145.9707,2020-03-06,1,0,0
 ,Saudi Arabia,24,45,2020-03-04,43,31,0
 ,Saudi Arabia,24,45,2020-03-05,47,31,0
 ,Saudi Arabia,24,45,2020-03-06,48,31,0
+,Saudi Arabia,24,45,2020-03-07,50,31,0
 ,Senegal,14.4974,-14.4524,2020-01-22,2,0,0
 ,Senegal,14.4974,-14.4524,2020-01-23,3,0,0
 ,Senegal,14.4974,-14.4524,2020-01-24,5,0,0
@@ -5849,6 +5840,7 @@ Tasmania,Australia,-41.4545,145.9707,2020-03-06,1,0,0
 ,Senegal,14.4974,-14.4524,2020-03-04,43,31,0
 ,Senegal,14.4974,-14.4524,2020-03-05,47,31,0
 ,Senegal,14.4974,-14.4524,2020-03-06,48,31,0
+,Senegal,14.4974,-14.4524,2020-03-07,50,31,0
 "Grafton County, NH",US,43.9088,-71.826,2020-01-22,0,0,0
 "Grafton County, NH",US,43.9088,-71.826,2020-01-23,0,0,0
 "Grafton County, NH",US,43.9088,-71.826,2020-01-24,0,0,0
@@ -5894,6 +5886,7 @@ Tasmania,Australia,-41.4545,145.9707,2020-03-06,1,0,0
 "Grafton County, NH",US,43.9088,-71.826,2020-03-04,2,0,0
 "Grafton County, NH",US,43.9088,-71.826,2020-03-05,2,0,0
 "Grafton County, NH",US,43.9088,-71.826,2020-03-06,2,0,0
+"Grafton County, NH",US,43.9088,-71.826,2020-03-07,2,0,0
 "Hillsborough, FL",US,27.9904,-82.3018,2020-01-22,0,0,0
 "Hillsborough, FL",US,27.9904,-82.3018,2020-01-23,0,0,0
 "Hillsborough, FL",US,27.9904,-82.3018,2020-01-24,0,0,0
@@ -5939,6 +5932,7 @@ Tasmania,Australia,-41.4545,145.9707,2020-03-06,1,0,0
 "Hillsborough, FL",US,27.9904,-82.3018,2020-03-04,2,0,0
 "Hillsborough, FL",US,27.9904,-82.3018,2020-03-05,2,0,0
 "Hillsborough, FL",US,27.9904,-82.3018,2020-03-06,2,0,0
+"Hillsborough, FL",US,27.9904,-82.3018,2020-03-07,2,0,0
 "Placer County, CA",US,39.0916,-120.8039,2020-01-22,0,0,0
 "Placer County, CA",US,39.0916,-120.8039,2020-01-23,0,0,0
 "Placer County, CA",US,39.0916,-120.8039,2020-01-24,0,0,0
@@ -5984,6 +5978,7 @@ Tasmania,Australia,-41.4545,145.9707,2020-03-06,1,0,0
 "Placer County, CA",US,39.0916,-120.8039,2020-03-04,2,0,1
 "Placer County, CA",US,39.0916,-120.8039,2020-03-05,2,0,1
 "Placer County, CA",US,39.0916,-120.8039,2020-03-06,5,0,1
+"Placer County, CA",US,39.0916,-120.8039,2020-03-07,5,0,1
 "San Mateo, CA",US,37.563,-122.3255,2020-01-22,0,0,0
 "San Mateo, CA",US,37.563,-122.3255,2020-01-23,0,0,0
 "San Mateo, CA",US,37.563,-122.3255,2020-01-24,0,0,0
@@ -6029,6 +6024,7 @@ Tasmania,Australia,-41.4545,145.9707,2020-03-06,1,0,0
 "San Mateo, CA",US,37.563,-122.3255,2020-03-04,2,0,0
 "San Mateo, CA",US,37.563,-122.3255,2020-03-05,2,0,0
 "San Mateo, CA",US,37.563,-122.3255,2020-03-06,2,0,0
+"San Mateo, CA",US,37.563,-122.3255,2020-03-07,2,0,0
 "Sarasota, FL",US,27.3364,-82.5307,2020-01-22,0,0,0
 "Sarasota, FL",US,27.3364,-82.5307,2020-01-23,0,0,0
 "Sarasota, FL",US,27.3364,-82.5307,2020-01-24,0,0,0
@@ -6074,6 +6070,7 @@ Tasmania,Australia,-41.4545,145.9707,2020-03-06,1,0,0
 "Sarasota, FL",US,27.3364,-82.5307,2020-03-04,1,0,0
 "Sarasota, FL",US,27.3364,-82.5307,2020-03-05,1,0,0
 "Sarasota, FL",US,27.3364,-82.5307,2020-03-06,1,0,0
+"Sarasota, FL",US,27.3364,-82.5307,2020-03-07,1,0,0
 "Sonoma County, CA",US,38.578,-122.9888,2020-01-22,0,0,0
 "Sonoma County, CA",US,38.578,-122.9888,2020-01-23,0,0,0
 "Sonoma County, CA",US,38.578,-122.9888,2020-01-24,0,0,0
@@ -6119,6 +6116,7 @@ Tasmania,Australia,-41.4545,145.9707,2020-03-06,1,0,0
 "Sonoma County, CA",US,38.578,-122.9888,2020-03-04,1,0,0
 "Sonoma County, CA",US,38.578,-122.9888,2020-03-05,1,0,0
 "Sonoma County, CA",US,38.578,-122.9888,2020-03-06,1,0,0
+"Sonoma County, CA",US,38.578,-122.9888,2020-03-07,1,0,0
 "Umatilla, OR",US,45.775,-118.7606,2020-01-22,0,0,0
 "Umatilla, OR",US,45.775,-118.7606,2020-01-23,0,0,0
 "Umatilla, OR",US,45.775,-118.7606,2020-01-24,0,0,0
@@ -6164,6 +6162,7 @@ Tasmania,Australia,-41.4545,145.9707,2020-03-06,1,0,0
 "Umatilla, OR",US,45.775,-118.7606,2020-03-04,1,0,0
 "Umatilla, OR",US,45.775,-118.7606,2020-03-05,1,0,0
 "Umatilla, OR",US,45.775,-118.7606,2020-03-06,1,0,0
+"Umatilla, OR",US,45.775,-118.7606,2020-03-07,1,0,0
 "Fulton County, GA",US,33.8034,-84.3963,2020-01-22,0,0,0
 "Fulton County, GA",US,33.8034,-84.3963,2020-01-23,0,0,0
 "Fulton County, GA",US,33.8034,-84.3963,2020-01-24,0,0,0
@@ -6209,6 +6208,7 @@ Tasmania,Australia,-41.4545,145.9707,2020-03-06,1,0,0
 "Fulton County, GA",US,33.8034,-84.3963,2020-03-04,2,0,0
 "Fulton County, GA",US,33.8034,-84.3963,2020-03-05,2,0,0
 "Fulton County, GA",US,33.8034,-84.3963,2020-03-06,2,0,0
+"Fulton County, GA",US,33.8034,-84.3963,2020-03-07,3,0,0
 "Washington County, OR",US,45.547,-123.1386,2020-01-22,0,0,0
 "Washington County, OR",US,45.547,-123.1386,2020-01-23,0,0,0
 "Washington County, OR",US,45.547,-123.1386,2020-01-24,0,0,0
@@ -6254,6 +6254,7 @@ Tasmania,Australia,-41.4545,145.9707,2020-03-06,1,0,0
 "Washington County, OR",US,45.547,-123.1386,2020-03-04,2,0,0
 "Washington County, OR",US,45.547,-123.1386,2020-03-05,2,0,0
 "Washington County, OR",US,45.547,-123.1386,2020-03-06,2,0,0
+"Washington County, OR",US,45.547,-123.1386,2020-03-07,3,0,0
 ,Argentina,-38.4161,-63.6167,2020-01-22,2,0,0
 ,Argentina,-38.4161,-63.6167,2020-01-23,3,0,0
 ,Argentina,-38.4161,-63.6167,2020-01-24,5,0,0
@@ -6299,6 +6300,7 @@ Tasmania,Australia,-41.4545,145.9707,2020-03-06,1,0,0
 ,Argentina,-38.4161,-63.6167,2020-03-04,43,31,0
 ,Argentina,-38.4161,-63.6167,2020-03-05,47,31,0
 ,Argentina,-38.4161,-63.6167,2020-03-06,48,31,0
+,Argentina,-38.4161,-63.6167,2020-03-07,50,31,0
 ,Chile,-35.6751,-71.543,2020-01-22,2,0,0
 ,Chile,-35.6751,-71.543,2020-01-23,3,0,0
 ,Chile,-35.6751,-71.543,2020-01-24,5,0,0
@@ -6344,6 +6346,7 @@ Tasmania,Australia,-41.4545,145.9707,2020-03-06,1,0,0
 ,Chile,-35.6751,-71.543,2020-03-04,43,31,0
 ,Chile,-35.6751,-71.543,2020-03-05,47,31,0
 ,Chile,-35.6751,-71.543,2020-03-06,48,31,0
+,Chile,-35.6751,-71.543,2020-03-07,50,31,0
 ,Jordan,31.24,36.51,2020-01-22,2,0,0
 ,Jordan,31.24,36.51,2020-01-23,3,0,0
 ,Jordan,31.24,36.51,2020-01-24,5,0,0
@@ -6389,6 +6392,7 @@ Tasmania,Australia,-41.4545,145.9707,2020-03-06,1,0,0
 ,Jordan,31.24,36.51,2020-03-04,43,31,0
 ,Jordan,31.24,36.51,2020-03-05,47,31,0
 ,Jordan,31.24,36.51,2020-03-06,48,31,0
+,Jordan,31.24,36.51,2020-03-07,50,31,0
 "Norfolk County, MA",US,42.1767,-71.1449,2020-01-22,0,0,0
 "Norfolk County, MA",US,42.1767,-71.1449,2020-01-23,0,0,0
 "Norfolk County, MA",US,42.1767,-71.1449,2020-01-24,0,0,0
@@ -6434,96 +6438,53 @@ Tasmania,Australia,-41.4545,145.9707,2020-03-06,1,0,0
 "Norfolk County, MA",US,42.1767,-71.1449,2020-03-04,1,0,0
 "Norfolk County, MA",US,42.1767,-71.1449,2020-03-05,1,0,0
 "Norfolk County, MA",US,42.1767,-71.1449,2020-03-06,2,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-01-22,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-01-23,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-01-24,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-01-25,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-01-26,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-01-27,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-01-28,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-01-29,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-01-30,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-01-31,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-02-01,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-02-02,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-02-03,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-02-04,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-02-05,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-02-06,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-02-07,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-02-08,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-02-09,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-02-10,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-02-11,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-02-12,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-02-13,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-02-14,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-02-15,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-02-16,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-02-17,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-02-18,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-02-19,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-02-20,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-02-21,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-02-22,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-02-23,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-02-24,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-02-25,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-02-26,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-02-27,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-02-28,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-02-29,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-03-01,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-03-02,0,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-03-03,1,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-03-04,1,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-03-05,1,0,0
-"Berkeley, CA",US,37.8715,-122.273,2020-03-06,1,0,0
+"Norfolk County, MA",US,42.1767,-71.1449,2020-03-07,2,0,0
 "Maricopa County, AZ",US,33.2918,-112.4291,2020-01-22,0,0,0
 "Maricopa County, AZ",US,33.2918,-112.4291,2020-01-23,0,0,0
 "Maricopa County, AZ",US,33.2918,-112.4291,2020-01-24,0,0,0
 "Maricopa County, AZ",US,33.2918,-112.4291,2020-01-25,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-01-26,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-01-27,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-01-28,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-01-29,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-01-30,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-01-31,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-01,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-02,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-03,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-04,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-05,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-06,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-07,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-08,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-09,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-10,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-11,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-12,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-13,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-14,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-15,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-16,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-17,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-18,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-19,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-20,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-21,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-22,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-23,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-24,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-25,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-26,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-27,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-28,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-29,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-03-01,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-03-02,0,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-03-03,1,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-03-04,1,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-03-05,1,0,0
-"Maricopa County, AZ",US,33.2918,-112.4291,2020-03-06,2,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-01-26,1,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-01-27,1,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-01-28,1,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-01-29,1,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-01-30,1,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-01-31,1,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-01,1,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-02,1,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-03,1,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-04,1,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-05,1,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-06,1,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-07,1,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-08,1,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-09,1,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-10,1,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-11,1,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-12,1,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-13,1,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-14,1,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-15,1,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-16,1,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-17,1,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-18,1,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-19,1,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-20,1,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-21,1,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-22,1,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-23,1,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-24,1,0,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-25,1,1,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-26,1,1,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-27,1,1,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-28,1,1,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-02-29,1,1,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-03-01,1,1,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-03-02,1,1,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-03-03,1,1,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-03-04,1,1,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-03-05,1,1,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-03-06,2,1,0
+"Maricopa County, AZ",US,33.2918,-112.4291,2020-03-07,3,1,0
 "Wake County, NC",US,35.8032,-78.5661,2020-01-22,0,0,0
 "Wake County, NC",US,35.8032,-78.5661,2020-01-23,0,0,0
 "Wake County, NC",US,35.8032,-78.5661,2020-01-24,0,0,0
@@ -6569,6 +6530,7 @@ Tasmania,Australia,-41.4545,145.9707,2020-03-06,1,0,0
 "Wake County, NC",US,35.8032,-78.5661,2020-03-04,1,0,0
 "Wake County, NC",US,35.8032,-78.5661,2020-03-05,1,0,0
 "Wake County, NC",US,35.8032,-78.5661,2020-03-06,1,0,0
+"Wake County, NC",US,35.8032,-78.5661,2020-03-07,1,0,0
 "Westchester County, NY",US,41.122,-73.7949,2020-01-22,0,0,0
 "Westchester County, NY",US,41.122,-73.7949,2020-01-23,0,0,0
 "Westchester County, NY",US,41.122,-73.7949,2020-01-24,0,0,0
@@ -6614,6 +6576,7 @@ Tasmania,Australia,-41.4545,145.9707,2020-03-06,1,0,0
 "Westchester County, NY",US,41.122,-73.7949,2020-03-04,10,0,0
 "Westchester County, NY",US,41.122,-73.7949,2020-03-05,18,0,0
 "Westchester County, NY",US,41.122,-73.7949,2020-03-06,19,0,0
+"Westchester County, NY",US,41.122,-73.7949,2020-03-07,57,0,0
 ,Ukraine,48.3794,31.1656,2020-01-22,2,0,0
 ,Ukraine,48.3794,31.1656,2020-01-23,3,0,0
 ,Ukraine,48.3794,31.1656,2020-01-24,5,0,0
@@ -6659,6 +6622,7 @@ Tasmania,Australia,-41.4545,145.9707,2020-03-06,1,0,0
 ,Ukraine,48.3794,31.1656,2020-03-04,43,31,0
 ,Ukraine,48.3794,31.1656,2020-03-05,47,31,0
 ,Ukraine,48.3794,31.1656,2020-03-06,48,31,0
+,Ukraine,48.3794,31.1656,2020-03-07,50,31,0
 ,Saint Barthelemy,17.9,-62.8333,2020-01-22,2,0,0
 ,Saint Barthelemy,17.9,-62.8333,2020-01-23,3,0,0
 ,Saint Barthelemy,17.9,-62.8333,2020-01-24,5,0,0
@@ -6704,6 +6668,7 @@ Tasmania,Australia,-41.4545,145.9707,2020-03-06,1,0,0
 ,Saint Barthelemy,17.9,-62.8333,2020-03-04,43,31,0
 ,Saint Barthelemy,17.9,-62.8333,2020-03-05,47,31,0
 ,Saint Barthelemy,17.9,-62.8333,2020-03-06,48,31,0
+,Saint Barthelemy,17.9,-62.8333,2020-03-07,50,31,0
 "Orange County, CA",US,33.7879,-117.8531,2020-01-22,0,0,0
 "Orange County, CA",US,33.7879,-117.8531,2020-01-23,0,0,0
 "Orange County, CA",US,33.7879,-117.8531,2020-01-24,0,0,0
@@ -6749,6 +6714,7 @@ Tasmania,Australia,-41.4545,145.9707,2020-03-06,1,0,0
 "Orange County, CA",US,33.7879,-117.8531,2020-03-04,3,0,0
 "Orange County, CA",US,33.7879,-117.8531,2020-03-05,3,0,0
 "Orange County, CA",US,33.7879,-117.8531,2020-03-06,3,0,0
+"Orange County, CA",US,33.7879,-117.8531,2020-03-07,3,0,0
 ,Hungary,47.1625,19.5033,2020-01-22,2,0,0
 ,Hungary,47.1625,19.5033,2020-01-23,3,0,0
 ,Hungary,47.1625,19.5033,2020-01-24,5,0,0
@@ -6794,6 +6760,7 @@ Tasmania,Australia,-41.4545,145.9707,2020-03-06,1,0,0
 ,Hungary,47.1625,19.5033,2020-03-04,43,31,0
 ,Hungary,47.1625,19.5033,2020-03-05,47,31,0
 ,Hungary,47.1625,19.5033,2020-03-06,48,31,0
+,Hungary,47.1625,19.5033,2020-03-07,50,31,0
 Northern Territory,Australia,-12.4634,130.8456,2020-01-22,0,0,0
 Northern Territory,Australia,-12.4634,130.8456,2020-01-23,0,0,0
 Northern Territory,Australia,-12.4634,130.8456,2020-01-24,0,0,0
@@ -6839,6 +6806,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-03,0,0,0
 Northern Territory,Australia,-12.4634,130.8456,2020-03-04,1,0,0
 Northern Territory,Australia,-12.4634,130.8456,2020-03-05,1,0,0
 Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
+Northern Territory,Australia,-12.4634,130.8456,2020-03-07,0,0,0
 ,Faroe Islands,61.8926,-6.9118,2020-01-22,2,0,0
 ,Faroe Islands,61.8926,-6.9118,2020-01-23,3,0,0
 ,Faroe Islands,61.8926,-6.9118,2020-01-24,5,0,0
@@ -6884,6 +6852,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 ,Faroe Islands,61.8926,-6.9118,2020-03-04,43,31,0
 ,Faroe Islands,61.8926,-6.9118,2020-03-05,47,31,0
 ,Faroe Islands,61.8926,-6.9118,2020-03-06,48,31,0
+,Faroe Islands,61.8926,-6.9118,2020-03-07,50,31,0
 ,Gibraltar,36.1408,-5.3536,2020-01-22,2,0,0
 ,Gibraltar,36.1408,-5.3536,2020-01-23,3,0,0
 ,Gibraltar,36.1408,-5.3536,2020-01-24,5,0,0
@@ -6929,6 +6898,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 ,Gibraltar,36.1408,-5.3536,2020-03-04,43,31,0
 ,Gibraltar,36.1408,-5.3536,2020-03-05,47,31,0
 ,Gibraltar,36.1408,-5.3536,2020-03-06,48,31,0
+,Gibraltar,36.1408,-5.3536,2020-03-07,50,31,0
 ,Liechtenstein,47.14,9.55,2020-01-22,2,0,0
 ,Liechtenstein,47.14,9.55,2020-01-23,3,0,0
 ,Liechtenstein,47.14,9.55,2020-01-24,5,0,0
@@ -6974,6 +6944,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 ,Liechtenstein,47.14,9.55,2020-03-04,43,31,0
 ,Liechtenstein,47.14,9.55,2020-03-05,47,31,0
 ,Liechtenstein,47.14,9.55,2020-03-06,48,31,0
+,Liechtenstein,47.14,9.55,2020-03-07,50,31,0
 ,Poland,51.9194,19.1451,2020-01-22,2,0,0
 ,Poland,51.9194,19.1451,2020-01-23,3,0,0
 ,Poland,51.9194,19.1451,2020-01-24,5,0,0
@@ -7019,6 +6990,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 ,Poland,51.9194,19.1451,2020-03-04,43,31,0
 ,Poland,51.9194,19.1451,2020-03-05,47,31,0
 ,Poland,51.9194,19.1451,2020-03-06,48,31,0
+,Poland,51.9194,19.1451,2020-03-07,50,31,0
 ,Tunisia,34,9,2020-01-22,2,0,0
 ,Tunisia,34,9,2020-01-23,3,0,0
 ,Tunisia,34,9,2020-01-24,5,0,0
@@ -7064,6 +7036,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 ,Tunisia,34,9,2020-03-04,43,31,0
 ,Tunisia,34,9,2020-03-05,47,31,0
 ,Tunisia,34,9,2020-03-06,48,31,0
+,Tunisia,34,9,2020-03-07,50,31,0
 "Contra Costa County, CA",US,37.8534,-121.9018,2020-01-22,0,0,0
 "Contra Costa County, CA",US,37.8534,-121.9018,2020-01-23,0,0,0
 "Contra Costa County, CA",US,37.8534,-121.9018,2020-01-24,0,0,0
@@ -7109,6 +7082,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 "Contra Costa County, CA",US,37.8534,-121.9018,2020-03-04,1,0,0
 "Contra Costa County, CA",US,37.8534,-121.9018,2020-03-05,1,0,0
 "Contra Costa County, CA",US,37.8534,-121.9018,2020-03-06,3,0,0
+"Contra Costa County, CA",US,37.8534,-121.9018,2020-03-07,3,0,0
 ,Palestine,31.9522,35.2332,2020-01-22,2,0,0
 ,Palestine,31.9522,35.2332,2020-01-23,3,0,0
 ,Palestine,31.9522,35.2332,2020-01-24,5,0,0
@@ -7154,6 +7128,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 ,Palestine,31.9522,35.2332,2020-03-04,43,31,0
 ,Palestine,31.9522,35.2332,2020-03-05,47,31,0
 ,Palestine,31.9522,35.2332,2020-03-06,48,31,0
+,Palestine,31.9522,35.2332,2020-03-07,50,31,0
 ,Bosnia and Herzegovina,43.9159,17.6791,2020-01-22,2,0,0
 ,Bosnia and Herzegovina,43.9159,17.6791,2020-01-23,3,0,0
 ,Bosnia and Herzegovina,43.9159,17.6791,2020-01-24,5,0,0
@@ -7199,6 +7174,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 ,Bosnia and Herzegovina,43.9159,17.6791,2020-03-04,43,31,0
 ,Bosnia and Herzegovina,43.9159,17.6791,2020-03-05,47,31,0
 ,Bosnia and Herzegovina,43.9159,17.6791,2020-03-06,48,31,0
+,Bosnia and Herzegovina,43.9159,17.6791,2020-03-07,50,31,0
 ,Slovenia,46.1512,14.9955,2020-01-22,2,0,0
 ,Slovenia,46.1512,14.9955,2020-01-23,3,0,0
 ,Slovenia,46.1512,14.9955,2020-01-24,5,0,0
@@ -7244,6 +7220,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 ,Slovenia,46.1512,14.9955,2020-03-04,43,31,0
 ,Slovenia,46.1512,14.9955,2020-03-05,47,31,0
 ,Slovenia,46.1512,14.9955,2020-03-06,48,31,0
+,Slovenia,46.1512,14.9955,2020-03-07,50,31,0
 "Bergen County, NJ",US,40.9263,-74.077,2020-01-22,0,0,0
 "Bergen County, NJ",US,40.9263,-74.077,2020-01-23,0,0,0
 "Bergen County, NJ",US,40.9263,-74.077,2020-01-24,0,0,0
@@ -7289,6 +7266,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 "Bergen County, NJ",US,40.9263,-74.077,2020-03-04,0,0,0
 "Bergen County, NJ",US,40.9263,-74.077,2020-03-05,2,0,0
 "Bergen County, NJ",US,40.9263,-74.077,2020-03-06,2,0,0
+"Bergen County, NJ",US,40.9263,-74.077,2020-03-07,4,0,0
 "Harris County, TX",US,29.7752,-95.3103,2020-01-22,0,0,0
 "Harris County, TX",US,29.7752,-95.3103,2020-01-23,0,0,0
 "Harris County, TX",US,29.7752,-95.3103,2020-01-24,0,0,0
@@ -7334,6 +7312,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 "Harris County, TX",US,29.7752,-95.3103,2020-03-04,0,0,0
 "Harris County, TX",US,29.7752,-95.3103,2020-03-05,2,0,0
 "Harris County, TX",US,29.7752,-95.3103,2020-03-06,3,0,0
+"Harris County, TX",US,29.7752,-95.3103,2020-03-07,5,0,0
 "San Francisco County, CA",US,37.7749,-122.4194,2020-01-22,0,0,0
 "San Francisco County, CA",US,37.7749,-122.4194,2020-01-23,0,0,0
 "San Francisco County, CA",US,37.7749,-122.4194,2020-01-24,0,0,0
@@ -7379,6 +7358,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 "San Francisco County, CA",US,37.7749,-122.4194,2020-03-04,0,0,0
 "San Francisco County, CA",US,37.7749,-122.4194,2020-03-05,2,0,0
 "San Francisco County, CA",US,37.7749,-122.4194,2020-03-06,2,0,0
+"San Francisco County, CA",US,37.7749,-122.4194,2020-03-07,9,0,0
 ,South Africa,-30.5595,22.9375,2020-01-22,2,0,0
 ,South Africa,-30.5595,22.9375,2020-01-23,3,0,0
 ,South Africa,-30.5595,22.9375,2020-01-24,5,0,0
@@ -7424,6 +7404,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 ,South Africa,-30.5595,22.9375,2020-03-04,43,31,0
 ,South Africa,-30.5595,22.9375,2020-03-05,47,31,0
 ,South Africa,-30.5595,22.9375,2020-03-06,48,31,0
+,South Africa,-30.5595,22.9375,2020-03-07,50,31,0
 "Clark County, NV",US,36.0796,-115.094,2020-01-22,0,0,0
 "Clark County, NV",US,36.0796,-115.094,2020-01-23,0,0,0
 "Clark County, NV",US,36.0796,-115.094,2020-01-24,0,0,0
@@ -7469,6 +7450,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 "Clark County, NV",US,36.0796,-115.094,2020-03-04,0,0,0
 "Clark County, NV",US,36.0796,-115.094,2020-03-05,1,0,0
 "Clark County, NV",US,36.0796,-115.094,2020-03-06,1,0,0
+"Clark County, NV",US,36.0796,-115.094,2020-03-07,1,0,0
 "Fort Bend County, TX",US,29.5693,-95.8143,2020-01-22,0,0,0
 "Fort Bend County, TX",US,29.5693,-95.8143,2020-01-23,0,0,0
 "Fort Bend County, TX",US,29.5693,-95.8143,2020-01-24,0,0,0
@@ -7514,6 +7496,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 "Fort Bend County, TX",US,29.5693,-95.8143,2020-03-04,0,0,0
 "Fort Bend County, TX",US,29.5693,-95.8143,2020-03-05,1,0,0
 "Fort Bend County, TX",US,29.5693,-95.8143,2020-03-06,1,0,0
+"Fort Bend County, TX",US,29.5693,-95.8143,2020-03-07,3,0,0
 "Grant County, WA",US,47.1981,-119.3732,2020-01-22,0,0,0
 "Grant County, WA",US,47.1981,-119.3732,2020-01-23,0,0,0
 "Grant County, WA",US,47.1981,-119.3732,2020-01-24,0,0,0
@@ -7559,6 +7542,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 "Grant County, WA",US,47.1981,-119.3732,2020-03-04,0,0,0
 "Grant County, WA",US,47.1981,-119.3732,2020-03-05,1,0,0
 "Grant County, WA",US,47.1981,-119.3732,2020-03-06,1,0,0
+"Grant County, WA",US,47.1981,-119.3732,2020-03-07,1,0,0
 "Santa Rosa County, FL",US,30.769,-86.9824,2020-01-22,0,0,0
 "Santa Rosa County, FL",US,30.769,-86.9824,2020-01-23,0,0,0
 "Santa Rosa County, FL",US,30.769,-86.9824,2020-01-24,0,0,0
@@ -7604,6 +7588,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 "Santa Rosa County, FL",US,30.769,-86.9824,2020-03-04,0,0,0
 "Santa Rosa County, FL",US,30.769,-86.9824,2020-03-05,1,0,0
 "Santa Rosa County, FL",US,30.769,-86.9824,2020-03-06,1,0,0
+"Santa Rosa County, FL",US,30.769,-86.9824,2020-03-07,1,0,0
 "Williamson County, TN",US,35.9179,-86.8622,2020-01-22,0,0,0
 "Williamson County, TN",US,35.9179,-86.8622,2020-01-23,0,0,0
 "Williamson County, TN",US,35.9179,-86.8622,2020-01-24,0,0,0
@@ -7649,6 +7634,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 "Williamson County, TN",US,35.9179,-86.8622,2020-03-04,0,0,0
 "Williamson County, TN",US,35.9179,-86.8622,2020-03-05,1,0,0
 "Williamson County, TN",US,35.9179,-86.8622,2020-03-06,1,0,0
+"Williamson County, TN",US,35.9179,-86.8622,2020-03-07,1,0,0
 "New York County, NY",US,40.7128,-74.006,2020-01-22,0,0,0
 "New York County, NY",US,40.7128,-74.006,2020-01-23,0,0,0
 "New York County, NY",US,40.7128,-74.006,2020-01-24,0,0,0
@@ -7694,6 +7680,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 "New York County, NY",US,40.7128,-74.006,2020-03-04,1,0,0
 "New York County, NY",US,40.7128,-74.006,2020-03-05,4,0,0
 "New York County, NY",US,40.7128,-74.006,2020-03-06,16,0,0
+"New York County, NY",US,40.7128,-74.006,2020-03-07,11,0,0
 "Unassigned Location, WA",US,47.7511,-120.7401,2020-01-22,0,0,0
 "Unassigned Location, WA",US,47.7511,-120.7401,2020-01-23,0,0,0
 "Unassigned Location, WA",US,47.7511,-120.7401,2020-01-24,0,0,0
@@ -7739,6 +7726,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 "Unassigned Location, WA",US,47.7511,-120.7401,2020-03-04,0,0,0
 "Unassigned Location, WA",US,47.7511,-120.7401,2020-03-05,0,0,0
 "Unassigned Location, WA",US,47.7511,-120.7401,2020-03-06,5,0,0
+"Unassigned Location, WA",US,47.7511,-120.7401,2020-03-07,5,0,0
 "Montgomery County, MD",US,39.1547,-77.2405,2020-01-22,0,0,0
 "Montgomery County, MD",US,39.1547,-77.2405,2020-01-23,0,0,0
 "Montgomery County, MD",US,39.1547,-77.2405,2020-01-24,0,0,0
@@ -7784,6 +7772,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 "Montgomery County, MD",US,39.1547,-77.2405,2020-03-04,0,0,0
 "Montgomery County, MD",US,39.1547,-77.2405,2020-03-05,0,0,0
 "Montgomery County, MD",US,39.1547,-77.2405,2020-03-06,3,0,0
+"Montgomery County, MD",US,39.1547,-77.2405,2020-03-07,3,0,0
 "Suffolk County, MA",US,42.3601,-71.0589,2020-01-22,0,0,0
 "Suffolk County, MA",US,42.3601,-71.0589,2020-01-23,0,0,0
 "Suffolk County, MA",US,42.3601,-71.0589,2020-01-24,0,0,0
@@ -7829,6 +7818,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 "Suffolk County, MA",US,42.3601,-71.0589,2020-03-04,1,1,0
 "Suffolk County, MA",US,42.3601,-71.0589,2020-03-05,1,1,0
 "Suffolk County, MA",US,42.3601,-71.0589,2020-03-06,3,1,0
+"Suffolk County, MA",US,42.3601,-71.0589,2020-03-07,3,1,0
 "Denver County, CO",US,39.7392,-104.9903,2020-01-22,0,0,0
 "Denver County, CO",US,39.7392,-104.9903,2020-01-23,0,0,0
 "Denver County, CO",US,39.7392,-104.9903,2020-01-24,0,0,0
@@ -7874,6 +7864,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 "Denver County, CO",US,39.7392,-104.9903,2020-03-04,0,0,0
 "Denver County, CO",US,39.7392,-104.9903,2020-03-05,0,0,0
 "Denver County, CO",US,39.7392,-104.9903,2020-03-06,2,0,0
+"Denver County, CO",US,39.7392,-104.9903,2020-03-07,2,0,0
 "Summit County, CO",US,39.5912,-106.064,2020-01-22,0,0,0
 "Summit County, CO",US,39.5912,-106.064,2020-01-23,0,0,0
 "Summit County, CO",US,39.5912,-106.064,2020-01-24,0,0,0
@@ -7919,6 +7910,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 "Summit County, CO",US,39.5912,-106.064,2020-03-04,0,0,0
 "Summit County, CO",US,39.5912,-106.064,2020-03-05,0,0,0
 "Summit County, CO",US,39.5912,-106.064,2020-03-06,2,0,0
+"Summit County, CO",US,39.5912,-106.064,2020-03-07,2,0,0
 ,Bhutan,27.5142,90.4336,2020-01-22,2,0,0
 ,Bhutan,27.5142,90.4336,2020-01-23,3,0,0
 ,Bhutan,27.5142,90.4336,2020-01-24,5,0,0
@@ -7964,6 +7956,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 ,Bhutan,27.5142,90.4336,2020-03-04,43,31,0
 ,Bhutan,27.5142,90.4336,2020-03-05,47,31,0
 ,Bhutan,27.5142,90.4336,2020-03-06,48,31,0
+,Bhutan,27.5142,90.4336,2020-03-07,50,31,0
 ,Cameroon,3.848,11.5021,2020-01-22,2,0,0
 ,Cameroon,3.848,11.5021,2020-01-23,3,0,0
 ,Cameroon,3.848,11.5021,2020-01-24,5,0,0
@@ -8009,6 +8002,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 ,Cameroon,3.848,11.5021,2020-03-04,43,31,0
 ,Cameroon,3.848,11.5021,2020-03-05,47,31,0
 ,Cameroon,3.848,11.5021,2020-03-06,48,31,0
+,Cameroon,3.848,11.5021,2020-03-07,50,31,0
 "Calgary, Alberta",Canada,51.0447,-114.0719,2020-01-22,0,0,0
 "Calgary, Alberta",Canada,51.0447,-114.0719,2020-01-23,0,0,0
 "Calgary, Alberta",Canada,51.0447,-114.0719,2020-01-24,0,0,0
@@ -8054,6 +8048,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 "Calgary, Alberta",Canada,51.0447,-114.0719,2020-03-04,0,0,0
 "Calgary, Alberta",Canada,51.0447,-114.0719,2020-03-05,0,0,0
 "Calgary, Alberta",Canada,51.0447,-114.0719,2020-03-06,1,0,0
+"Calgary, Alberta",Canada,51.0447,-114.0719,2020-03-07,1,0,0
 ,Colombia,4.5709,-74.2973,2020-01-22,2,0,0
 ,Colombia,4.5709,-74.2973,2020-01-23,3,0,0
 ,Colombia,4.5709,-74.2973,2020-01-24,5,0,0
@@ -8099,6 +8094,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 ,Colombia,4.5709,-74.2973,2020-03-04,43,31,0
 ,Colombia,4.5709,-74.2973,2020-03-05,47,31,0
 ,Colombia,4.5709,-74.2973,2020-03-06,48,31,0
+,Colombia,4.5709,-74.2973,2020-03-07,50,31,0
 ,Costa Rica,9.7489,-83.7534,2020-01-22,2,0,0
 ,Costa Rica,9.7489,-83.7534,2020-01-23,3,0,0
 ,Costa Rica,9.7489,-83.7534,2020-01-24,5,0,0
@@ -8144,6 +8140,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 ,Costa Rica,9.7489,-83.7534,2020-03-04,43,31,0
 ,Costa Rica,9.7489,-83.7534,2020-03-05,47,31,0
 ,Costa Rica,9.7489,-83.7534,2020-03-06,48,31,0
+,Costa Rica,9.7489,-83.7534,2020-03-07,50,31,0
 ,Peru,-9.19,-75.0152,2020-01-22,2,0,0
 ,Peru,-9.19,-75.0152,2020-01-23,3,0,0
 ,Peru,-9.19,-75.0152,2020-01-24,5,0,0
@@ -8189,6 +8186,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 ,Peru,-9.19,-75.0152,2020-03-04,43,31,0
 ,Peru,-9.19,-75.0152,2020-03-05,47,31,0
 ,Peru,-9.19,-75.0152,2020-03-06,48,31,0
+,Peru,-9.19,-75.0152,2020-03-07,50,31,0
 ,Serbia,44.0165,21.0059,2020-01-22,2,0,0
 ,Serbia,44.0165,21.0059,2020-01-23,3,0,0
 ,Serbia,44.0165,21.0059,2020-01-24,5,0,0
@@ -8234,6 +8232,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 ,Serbia,44.0165,21.0059,2020-03-04,43,31,0
 ,Serbia,44.0165,21.0059,2020-03-05,47,31,0
 ,Serbia,44.0165,21.0059,2020-03-06,48,31,0
+,Serbia,44.0165,21.0059,2020-03-07,50,31,0
 ,Slovakia,48.669,19.699,2020-01-22,2,0,0
 ,Slovakia,48.669,19.699,2020-01-23,3,0,0
 ,Slovakia,48.669,19.699,2020-01-24,5,0,0
@@ -8279,6 +8278,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 ,Slovakia,48.669,19.699,2020-03-04,43,31,0
 ,Slovakia,48.669,19.699,2020-03-05,47,31,0
 ,Slovakia,48.669,19.699,2020-03-06,48,31,0
+,Slovakia,48.669,19.699,2020-03-07,50,31,0
 ,Togo,8.6195,0.8248,2020-01-22,2,0,0
 ,Togo,8.6195,0.8248,2020-01-23,3,0,0
 ,Togo,8.6195,0.8248,2020-01-24,5,0,0
@@ -8324,6 +8324,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 ,Togo,8.6195,0.8248,2020-03-04,43,31,0
 ,Togo,8.6195,0.8248,2020-03-05,47,31,0
 ,Togo,8.6195,0.8248,2020-03-06,48,31,0
+,Togo,8.6195,0.8248,2020-03-07,50,31,0
 "Chatham County, NC",US,35.7211,-79.1781,2020-01-22,0,0,0
 "Chatham County, NC",US,35.7211,-79.1781,2020-01-23,0,0,0
 "Chatham County, NC",US,35.7211,-79.1781,2020-01-24,0,0,0
@@ -8369,6 +8370,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 "Chatham County, NC",US,35.7211,-79.1781,2020-03-04,0,0,0
 "Chatham County, NC",US,35.7211,-79.1781,2020-03-05,0,0,0
 "Chatham County, NC",US,35.7211,-79.1781,2020-03-06,1,0,0
+"Chatham County, NC",US,35.7211,-79.1781,2020-03-07,1,0,0
 "Delaware County, PA",US,39.9078,-75.3879,2020-01-22,0,0,0
 "Delaware County, PA",US,39.9078,-75.3879,2020-01-23,0,0,0
 "Delaware County, PA",US,39.9078,-75.3879,2020-01-24,0,0,0
@@ -8414,6 +8416,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 "Delaware County, PA",US,39.9078,-75.3879,2020-03-04,0,0,0
 "Delaware County, PA",US,39.9078,-75.3879,2020-03-05,0,0,0
 "Delaware County, PA",US,39.9078,-75.3879,2020-03-06,1,0,0
+"Delaware County, PA",US,39.9078,-75.3879,2020-03-07,1,0,0
 "Douglas County, NE",US,41.3148,-96.1951,2020-01-22,0,0,0
 "Douglas County, NE",US,41.3148,-96.1951,2020-01-23,0,0,0
 "Douglas County, NE",US,41.3148,-96.1951,2020-01-24,0,0,0
@@ -8459,6 +8462,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 "Douglas County, NE",US,41.3148,-96.1951,2020-03-04,0,0,0
 "Douglas County, NE",US,41.3148,-96.1951,2020-03-05,0,0,0
 "Douglas County, NE",US,41.3148,-96.1951,2020-03-06,1,0,0
+"Douglas County, NE",US,41.3148,-96.1951,2020-03-07,1,0,0
 "Fayette County, KY",US,38.0606,-84.4803,2020-01-22,0,0,0
 "Fayette County, KY",US,38.0606,-84.4803,2020-01-23,0,0,0
 "Fayette County, KY",US,38.0606,-84.4803,2020-01-24,0,0,0
@@ -8504,6 +8508,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 "Fayette County, KY",US,38.0606,-84.4803,2020-03-04,0,0,0
 "Fayette County, KY",US,38.0606,-84.4803,2020-03-05,0,0,0
 "Fayette County, KY",US,38.0606,-84.4803,2020-03-06,1,0,0
+"Fayette County, KY",US,38.0606,-84.4803,2020-03-07,1,0,0
 "Floyd County, GA",US,34.2829,-85.2308,2020-01-22,0,0,0
 "Floyd County, GA",US,34.2829,-85.2308,2020-01-23,0,0,0
 "Floyd County, GA",US,34.2829,-85.2308,2020-01-24,0,0,0
@@ -8549,6 +8554,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 "Floyd County, GA",US,34.2829,-85.2308,2020-03-04,0,0,0
 "Floyd County, GA",US,34.2829,-85.2308,2020-03-05,0,0,0
 "Floyd County, GA",US,34.2829,-85.2308,2020-03-06,1,0,0
+"Floyd County, GA",US,34.2829,-85.2308,2020-03-07,2,0,0
 "Marion County, IN",US,39.8362,-86.1752,2020-01-22,0,0,0
 "Marion County, IN",US,39.8362,-86.1752,2020-01-23,0,0,0
 "Marion County, IN",US,39.8362,-86.1752,2020-01-24,0,0,0
@@ -8594,6 +8600,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 "Marion County, IN",US,39.8362,-86.1752,2020-03-04,0,0,0
 "Marion County, IN",US,39.8362,-86.1752,2020-03-05,0,0,0
 "Marion County, IN",US,39.8362,-86.1752,2020-03-06,1,0,0
+"Marion County, IN",US,39.8362,-86.1752,2020-03-07,1,0,0
 "Middlesex County, MA",US,42.4672,-71.2874,2020-01-22,0,0,0
 "Middlesex County, MA",US,42.4672,-71.2874,2020-01-23,0,0,0
 "Middlesex County, MA",US,42.4672,-71.2874,2020-01-24,0,0,0
@@ -8639,6 +8646,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 "Middlesex County, MA",US,42.4672,-71.2874,2020-03-04,0,0,0
 "Middlesex County, MA",US,42.4672,-71.2874,2020-03-05,0,0,0
 "Middlesex County, MA",US,42.4672,-71.2874,2020-03-06,1,0,0
+"Middlesex County, MA",US,42.4672,-71.2874,2020-03-07,1,0,0
 "Nassau County, NY",US,40.6546,-73.5594,2020-01-22,0,0,0
 "Nassau County, NY",US,40.6546,-73.5594,2020-01-23,0,0,0
 "Nassau County, NY",US,40.6546,-73.5594,2020-01-24,0,0,0
@@ -8684,51 +8692,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 "Nassau County, NY",US,40.6546,-73.5594,2020-03-04,0,0,0
 "Nassau County, NY",US,40.6546,-73.5594,2020-03-05,1,0,0
 "Nassau County, NY",US,40.6546,-73.5594,2020-03-06,1,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-01-22,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-01-23,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-01-24,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-01-25,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-01-26,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-01-27,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-01-28,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-01-29,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-01-30,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-01-31,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-02-01,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-02-02,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-02-03,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-02-04,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-02-05,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-02-06,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-02-07,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-02-08,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-02-09,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-02-10,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-02-11,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-02-12,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-02-13,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-02-14,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-02-15,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-02-16,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-02-17,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-02-18,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-02-19,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-02-20,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-02-21,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-02-22,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-02-23,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-02-24,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-02-25,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-02-26,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-02-27,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-02-28,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-02-29,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-03-01,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-03-02,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-03-03,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-03-04,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-03-05,0,0,0
-"Norwell County, MA",US,42.1615,-70.7928,2020-03-06,1,0,0
+"Nassau County, NY",US,40.6546,-73.5594,2020-03-07,4,0,0
 "Ramsey County, MN",US,44.9964,-93.0616,2020-01-22,0,0,0
 "Ramsey County, MN",US,44.9964,-93.0616,2020-01-23,0,0,0
 "Ramsey County, MN",US,44.9964,-93.0616,2020-01-24,0,0,0
@@ -8774,6 +8738,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 "Ramsey County, MN",US,44.9964,-93.0616,2020-03-04,0,0,0
 "Ramsey County, MN",US,44.9964,-93.0616,2020-03-05,0,0,0
 "Ramsey County, MN",US,44.9964,-93.0616,2020-03-06,1,0,0
+"Ramsey County, MN",US,44.9964,-93.0616,2020-03-07,1,0,0
 "Washoe County, NV",US,40.5608,-119.6035,2020-01-22,0,0,0
 "Washoe County, NV",US,40.5608,-119.6035,2020-01-23,0,0,0
 "Washoe County, NV",US,40.5608,-119.6035,2020-01-24,0,0,0
@@ -8819,6 +8784,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 "Washoe County, NV",US,40.5608,-119.6035,2020-03-04,0,0,0
 "Washoe County, NV",US,40.5608,-119.6035,2020-03-05,0,0,0
 "Washoe County, NV",US,40.5608,-119.6035,2020-03-06,1,0,0
+"Washoe County, NV",US,40.5608,-119.6035,2020-03-07,1,0,0
 "Wayne County, PA",US,41.6739,-75.2479,2020-01-22,0,0,0
 "Wayne County, PA",US,41.6739,-75.2479,2020-01-23,0,0,0
 "Wayne County, PA",US,41.6739,-75.2479,2020-01-24,0,0,0
@@ -8864,6 +8830,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 "Wayne County, PA",US,41.6739,-75.2479,2020-03-04,0,0,0
 "Wayne County, PA",US,41.6739,-75.2479,2020-03-05,0,0,0
 "Wayne County, PA",US,41.6739,-75.2479,2020-03-06,1,0,0
+"Wayne County, PA",US,41.6739,-75.2479,2020-03-07,1,0,0
 "Yolo County, CA",US,38.7646,-121.9018,2020-01-22,0,0,0
 "Yolo County, CA",US,38.7646,-121.9018,2020-01-23,0,0,0
 "Yolo County, CA",US,38.7646,-121.9018,2020-01-24,0,0,0
@@ -8909,6 +8876,7 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 "Yolo County, CA",US,38.7646,-121.9018,2020-03-04,0,0,0
 "Yolo County, CA",US,38.7646,-121.9018,2020-03-05,0,0,0
 "Yolo County, CA",US,38.7646,-121.9018,2020-03-06,1,0,0
+"Yolo County, CA",US,38.7646,-121.9018,2020-03-07,1,0,0
 ,Vatican City,41.9029,12.4534,2020-01-22,2,0,0
 ,Vatican City,41.9029,12.4534,2020-01-23,3,0,0
 ,Vatican City,41.9029,12.4534,2020-01-24,5,0,0
@@ -8954,3 +8922,1430 @@ Northern Territory,Australia,-12.4634,130.8456,2020-03-06,0,0,0
 ,Vatican City,41.9029,12.4534,2020-03-04,43,31,0
 ,Vatican City,41.9029,12.4534,2020-03-05,47,31,0
 ,Vatican City,41.9029,12.4534,2020-03-06,48,31,0
+,Vatican City,41.9029,12.4534,2020-03-07,50,31,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-01-22,0,0,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-01-23,0,0,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-01-24,0,0,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-01-25,0,0,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-01-26,0,0,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-01-27,0,0,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-01-28,0,0,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-01-29,0,0,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-01-30,0,0,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-01-31,1,0,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-02-01,1,0,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-02-02,1,0,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-02-03,2,0,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-02-04,2,0,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-02-05,2,0,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-02-06,2,0,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-02-07,2,0,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-02-08,2,0,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-02-09,2,0,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-02-10,2,0,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-02-11,2,0,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-02-12,2,0,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-02-13,2,0,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-02-14,2,0,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-02-15,2,0,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-02-16,2,0,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-02-17,2,0,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-02-18,2,0,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-02-19,2,0,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-02-20,2,0,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-02-21,2,1,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-02-22,2,1,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-02-23,2,1,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-02-24,2,1,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-02-25,2,1,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-02-26,2,1,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-02-27,2,1,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-02-28,2,1,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-02-29,3,1,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-03-01,3,1,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-03-02,9,1,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-03-03,11,1,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-03-04,11,1,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-03-05,20,1,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-03-06,20,1,0
+"Santa Clara County, CA",US,37.3541,-121.9552,2020-03-07,32,1,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-01-22,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-01-23,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-01-24,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-01-25,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-01-26,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-01-27,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-01-28,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-01-29,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-01-30,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-01-31,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-02-01,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-02-02,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-02-03,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-02-04,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-02-05,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-02-06,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-02-07,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-02-08,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-02-09,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-02-10,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-02-11,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-02-12,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-02-13,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-02-14,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-02-15,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-02-16,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-02-17,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-02-18,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-02-19,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-02-20,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-02-21,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-02-22,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-02-23,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-02-24,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-02-25,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-02-26,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-02-27,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-02-28,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-02-29,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-03-01,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-03-02,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-03-03,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-03-04,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-03-05,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-03-06,0,0,0
+Grand Princess Cruise Ship,US,37.6489,-122.6655,2020-03-07,21,0,0
+,French Guiana,3.9339,-53.1258,2020-01-22,2,0,0
+,French Guiana,3.9339,-53.1258,2020-01-23,3,0,0
+,French Guiana,3.9339,-53.1258,2020-01-24,5,0,0
+,French Guiana,3.9339,-53.1258,2020-01-25,7,0,0
+,French Guiana,3.9339,-53.1258,2020-01-26,8,2,0
+,French Guiana,3.9339,-53.1258,2020-01-27,8,2,0
+,French Guiana,3.9339,-53.1258,2020-01-28,14,5,0
+,French Guiana,3.9339,-53.1258,2020-01-29,14,5,0
+,French Guiana,3.9339,-53.1258,2020-01-30,14,5,0
+,French Guiana,3.9339,-53.1258,2020-01-31,19,5,0
+,French Guiana,3.9339,-53.1258,2020-02-01,19,5,0
+,French Guiana,3.9339,-53.1258,2020-02-02,19,5,0
+,French Guiana,3.9339,-53.1258,2020-02-03,19,5,0
+,French Guiana,3.9339,-53.1258,2020-02-04,25,5,0
+,French Guiana,3.9339,-53.1258,2020-02-05,25,5,0
+,French Guiana,3.9339,-53.1258,2020-02-06,25,5,0
+,French Guiana,3.9339,-53.1258,2020-02-07,25,5,0
+,French Guiana,3.9339,-53.1258,2020-02-08,32,10,0
+,French Guiana,3.9339,-53.1258,2020-02-09,32,10,0
+,French Guiana,3.9339,-53.1258,2020-02-10,32,10,0
+,French Guiana,3.9339,-53.1258,2020-02-11,33,10,0
+,French Guiana,3.9339,-53.1258,2020-02-12,33,10,0
+,French Guiana,3.9339,-53.1258,2020-02-13,33,12,0
+,French Guiana,3.9339,-53.1258,2020-02-14,33,12,0
+,French Guiana,3.9339,-53.1258,2020-02-15,33,12,0
+,French Guiana,3.9339,-53.1258,2020-02-16,34,14,0
+,French Guiana,3.9339,-53.1258,2020-02-17,35,15,0
+,French Guiana,3.9339,-53.1258,2020-02-18,35,15,0
+,French Guiana,3.9339,-53.1258,2020-02-19,35,15,0
+,French Guiana,3.9339,-53.1258,2020-02-20,35,15,0
+,French Guiana,3.9339,-53.1258,2020-02-21,35,17,0
+,French Guiana,3.9339,-53.1258,2020-02-22,35,17,0
+,French Guiana,3.9339,-53.1258,2020-02-23,35,21,0
+,French Guiana,3.9339,-53.1258,2020-02-24,35,21,0
+,French Guiana,3.9339,-53.1258,2020-02-25,37,22,0
+,French Guiana,3.9339,-53.1258,2020-02-26,40,22,0
+,French Guiana,3.9339,-53.1258,2020-02-27,40,22,0
+,French Guiana,3.9339,-53.1258,2020-02-28,41,28,0
+,French Guiana,3.9339,-53.1258,2020-02-29,42,28,0
+,French Guiana,3.9339,-53.1258,2020-03-01,42,28,0
+,French Guiana,3.9339,-53.1258,2020-03-02,43,31,0
+,French Guiana,3.9339,-53.1258,2020-03-03,43,31,0
+,French Guiana,3.9339,-53.1258,2020-03-04,43,31,0
+,French Guiana,3.9339,-53.1258,2020-03-05,47,31,0
+,French Guiana,3.9339,-53.1258,2020-03-06,48,31,0
+,French Guiana,3.9339,-53.1258,2020-03-07,50,31,0
+,Malta,35.9375,14.3754,2020-01-22,2,0,0
+,Malta,35.9375,14.3754,2020-01-23,3,0,0
+,Malta,35.9375,14.3754,2020-01-24,5,0,0
+,Malta,35.9375,14.3754,2020-01-25,7,0,0
+,Malta,35.9375,14.3754,2020-01-26,8,2,0
+,Malta,35.9375,14.3754,2020-01-27,8,2,0
+,Malta,35.9375,14.3754,2020-01-28,14,5,0
+,Malta,35.9375,14.3754,2020-01-29,14,5,0
+,Malta,35.9375,14.3754,2020-01-30,14,5,0
+,Malta,35.9375,14.3754,2020-01-31,19,5,0
+,Malta,35.9375,14.3754,2020-02-01,19,5,0
+,Malta,35.9375,14.3754,2020-02-02,19,5,0
+,Malta,35.9375,14.3754,2020-02-03,19,5,0
+,Malta,35.9375,14.3754,2020-02-04,25,5,0
+,Malta,35.9375,14.3754,2020-02-05,25,5,0
+,Malta,35.9375,14.3754,2020-02-06,25,5,0
+,Malta,35.9375,14.3754,2020-02-07,25,5,0
+,Malta,35.9375,14.3754,2020-02-08,32,10,0
+,Malta,35.9375,14.3754,2020-02-09,32,10,0
+,Malta,35.9375,14.3754,2020-02-10,32,10,0
+,Malta,35.9375,14.3754,2020-02-11,33,10,0
+,Malta,35.9375,14.3754,2020-02-12,33,10,0
+,Malta,35.9375,14.3754,2020-02-13,33,12,0
+,Malta,35.9375,14.3754,2020-02-14,33,12,0
+,Malta,35.9375,14.3754,2020-02-15,33,12,0
+,Malta,35.9375,14.3754,2020-02-16,34,14,0
+,Malta,35.9375,14.3754,2020-02-17,35,15,0
+,Malta,35.9375,14.3754,2020-02-18,35,15,0
+,Malta,35.9375,14.3754,2020-02-19,35,15,0
+,Malta,35.9375,14.3754,2020-02-20,35,15,0
+,Malta,35.9375,14.3754,2020-02-21,35,17,0
+,Malta,35.9375,14.3754,2020-02-22,35,17,0
+,Malta,35.9375,14.3754,2020-02-23,35,21,0
+,Malta,35.9375,14.3754,2020-02-24,35,21,0
+,Malta,35.9375,14.3754,2020-02-25,37,22,0
+,Malta,35.9375,14.3754,2020-02-26,40,22,0
+,Malta,35.9375,14.3754,2020-02-27,40,22,0
+,Malta,35.9375,14.3754,2020-02-28,41,28,0
+,Malta,35.9375,14.3754,2020-02-29,42,28,0
+,Malta,35.9375,14.3754,2020-03-01,42,28,0
+,Malta,35.9375,14.3754,2020-03-02,43,31,0
+,Malta,35.9375,14.3754,2020-03-03,43,31,0
+,Malta,35.9375,14.3754,2020-03-04,43,31,0
+,Malta,35.9375,14.3754,2020-03-05,47,31,0
+,Malta,35.9375,14.3754,2020-03-06,48,31,0
+,Malta,35.9375,14.3754,2020-03-07,50,31,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-01-22,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-01-23,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-01-24,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-01-25,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-01-26,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-01-27,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-01-28,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-01-29,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-01-30,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-01-31,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-02-01,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-02-02,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-02-03,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-02-04,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-02-05,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-02-06,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-02-07,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-02-08,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-02-09,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-02-10,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-02-11,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-02-12,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-02-13,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-02-14,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-02-15,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-02-16,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-02-17,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-02-18,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-02-19,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-02-20,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-02-21,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-02-22,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-02-23,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-02-24,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-02-25,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-02-26,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-02-27,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-02-28,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-02-29,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-03-01,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-03-02,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-03-03,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-03-04,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-03-05,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-03-06,0,0,0
+"Douglas County, CO",US,39.2587,-104.9389,2020-03-07,3,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-01-22,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-01-23,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-01-24,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-01-25,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-01-26,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-01-27,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-01-28,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-01-29,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-01-30,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-01-31,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-02-01,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-02-02,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-02-03,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-02-04,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-02-05,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-02-06,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-02-07,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-02-08,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-02-09,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-02-10,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-02-11,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-02-12,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-02-13,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-02-14,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-02-15,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-02-16,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-02-17,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-02-18,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-02-19,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-02-20,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-02-21,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-02-22,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-02-23,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-02-24,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-02-25,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-02-26,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-02-27,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-02-28,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-02-29,0,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-03-01,1,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-03-02,2,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-03-03,2,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-03-04,2,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-03-05,2,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-03-06,2,0,0
+"Providence County, RI",US,41.8882,-71.4774,2020-03-07,3,0,0
+,Martinique,14.6415,-61.0242,2020-01-22,2,0,0
+,Martinique,14.6415,-61.0242,2020-01-23,3,0,0
+,Martinique,14.6415,-61.0242,2020-01-24,5,0,0
+,Martinique,14.6415,-61.0242,2020-01-25,7,0,0
+,Martinique,14.6415,-61.0242,2020-01-26,8,2,0
+,Martinique,14.6415,-61.0242,2020-01-27,8,2,0
+,Martinique,14.6415,-61.0242,2020-01-28,14,5,0
+,Martinique,14.6415,-61.0242,2020-01-29,14,5,0
+,Martinique,14.6415,-61.0242,2020-01-30,14,5,0
+,Martinique,14.6415,-61.0242,2020-01-31,19,5,0
+,Martinique,14.6415,-61.0242,2020-02-01,19,5,0
+,Martinique,14.6415,-61.0242,2020-02-02,19,5,0
+,Martinique,14.6415,-61.0242,2020-02-03,19,5,0
+,Martinique,14.6415,-61.0242,2020-02-04,25,5,0
+,Martinique,14.6415,-61.0242,2020-02-05,25,5,0
+,Martinique,14.6415,-61.0242,2020-02-06,25,5,0
+,Martinique,14.6415,-61.0242,2020-02-07,25,5,0
+,Martinique,14.6415,-61.0242,2020-02-08,32,10,0
+,Martinique,14.6415,-61.0242,2020-02-09,32,10,0
+,Martinique,14.6415,-61.0242,2020-02-10,32,10,0
+,Martinique,14.6415,-61.0242,2020-02-11,33,10,0
+,Martinique,14.6415,-61.0242,2020-02-12,33,10,0
+,Martinique,14.6415,-61.0242,2020-02-13,33,12,0
+,Martinique,14.6415,-61.0242,2020-02-14,33,12,0
+,Martinique,14.6415,-61.0242,2020-02-15,33,12,0
+,Martinique,14.6415,-61.0242,2020-02-16,34,14,0
+,Martinique,14.6415,-61.0242,2020-02-17,35,15,0
+,Martinique,14.6415,-61.0242,2020-02-18,35,15,0
+,Martinique,14.6415,-61.0242,2020-02-19,35,15,0
+,Martinique,14.6415,-61.0242,2020-02-20,35,15,0
+,Martinique,14.6415,-61.0242,2020-02-21,35,17,0
+,Martinique,14.6415,-61.0242,2020-02-22,35,17,0
+,Martinique,14.6415,-61.0242,2020-02-23,35,21,0
+,Martinique,14.6415,-61.0242,2020-02-24,35,21,0
+,Martinique,14.6415,-61.0242,2020-02-25,37,22,0
+,Martinique,14.6415,-61.0242,2020-02-26,40,22,0
+,Martinique,14.6415,-61.0242,2020-02-27,40,22,0
+,Martinique,14.6415,-61.0242,2020-02-28,41,28,0
+,Martinique,14.6415,-61.0242,2020-02-29,42,28,0
+,Martinique,14.6415,-61.0242,2020-03-01,42,28,0
+,Martinique,14.6415,-61.0242,2020-03-02,43,31,0
+,Martinique,14.6415,-61.0242,2020-03-03,43,31,0
+,Martinique,14.6415,-61.0242,2020-03-04,43,31,0
+,Martinique,14.6415,-61.0242,2020-03-05,47,31,0
+,Martinique,14.6415,-61.0242,2020-03-06,48,31,0
+,Martinique,14.6415,-61.0242,2020-03-07,50,31,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-01-22,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-01-23,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-01-24,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-01-25,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-01-26,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-01-27,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-01-28,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-01-29,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-01-30,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-01-31,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-02-01,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-02-02,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-02-03,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-02-04,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-02-05,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-02-06,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-02-07,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-02-08,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-02-09,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-02-10,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-02-11,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-02-12,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-02-13,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-02-14,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-02-15,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-02-16,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-02-17,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-02-18,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-02-19,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-02-20,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-02-21,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-02-22,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-02-23,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-02-24,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-02-25,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-02-26,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-02-27,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-02-28,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-02-29,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-03-01,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-03-02,0,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-03-03,1,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-03-04,1,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-03-05,1,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-03-06,1,0,0
+"Alameda County, CA",US,37.6017,-121.7195,2020-03-07,2,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-01-22,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-01-23,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-01-24,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-01-25,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-01-26,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-01-27,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-01-28,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-01-29,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-01-30,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-01-31,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-02-01,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-02-02,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-02-03,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-02-04,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-02-05,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-02-06,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-02-07,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-02-08,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-02-09,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-02-10,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-02-11,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-02-12,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-02-13,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-02-14,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-02-15,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-02-16,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-02-17,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-02-18,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-02-19,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-02-20,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-02-21,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-02-22,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-02-23,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-02-24,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-02-25,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-02-26,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-02-27,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-02-28,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-02-29,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-03-01,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-03-02,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-03-03,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-03-04,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-03-05,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-03-06,0,0,0
+"Broward County, FL",US,26.1901,-80.3659,2020-03-07,2,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-01-22,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-01-23,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-01-24,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-01-25,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-01-26,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-01-27,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-01-28,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-01-29,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-01-30,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-01-31,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-02-01,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-02-02,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-02-03,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-02-04,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-02-05,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-02-06,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-02-07,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-02-08,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-02-09,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-02-10,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-02-11,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-02-12,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-02-13,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-02-14,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-02-15,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-02-16,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-02-17,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-02-18,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-02-19,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-02-20,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-02-21,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-02-22,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-02-23,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-02-24,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-02-25,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-02-26,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-02-27,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-02-28,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-02-29,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-03-01,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-03-02,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-03-03,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-03-04,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-03-05,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-03-06,0,0,0
+"Fairfield County, CT",US,41.256,-73.3709,2020-03-07,2,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-01-22,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-01-23,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-01-24,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-01-25,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-01-26,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-01-27,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-01-28,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-01-29,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-01-30,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-01-31,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-02-01,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-02-02,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-02-03,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-02-04,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-02-05,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-02-06,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-02-07,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-02-08,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-02-09,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-02-10,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-02-11,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-02-12,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-02-13,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-02-14,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-02-15,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-02-16,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-02-17,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-02-18,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-02-19,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-02-20,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-02-21,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-02-22,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-02-23,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-02-24,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-02-25,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-02-26,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-02-27,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-02-28,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-02-29,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-03-01,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-03-02,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-03-03,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-03-04,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-03-05,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-03-06,0,0,0
+"Lee County, FL",US,26.663,-81.9535,2020-03-07,2,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-01-22,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-01-23,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-01-24,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-01-25,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-01-26,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-01-27,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-01-28,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-01-29,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-01-30,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-01-31,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-02-01,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-02-02,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-02-03,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-02-04,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-02-05,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-02-06,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-02-07,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-02-08,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-02-09,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-02-10,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-02-11,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-02-12,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-02-13,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-02-14,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-02-15,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-02-16,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-02-17,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-02-18,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-02-19,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-02-20,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-02-21,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-02-22,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-02-23,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-02-24,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-02-25,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-02-26,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-02-27,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-02-28,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-02-29,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-03-01,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-03-02,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-03-03,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-03-04,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-03-05,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-03-06,0,0,0
+"Pinal County, AZ",US,32.8162,-111.2845,2020-03-07,2,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-01-22,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-01-23,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-01-24,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-01-25,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-01-26,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-01-27,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-01-28,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-01-29,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-01-30,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-01-31,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-02-01,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-02-02,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-02-03,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-02-04,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-02-05,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-02-06,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-02-07,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-02-08,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-02-09,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-02-10,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-02-11,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-02-12,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-02-13,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-02-14,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-02-15,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-02-16,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-02-17,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-02-18,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-02-19,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-02-20,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-02-21,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-02-22,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-02-23,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-02-24,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-02-25,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-02-26,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-02-27,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-02-28,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-02-29,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-03-01,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-03-02,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-03-03,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-03-04,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-03-05,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-03-06,0,0,0
+"Rockland County, NY",US,41.1489,-73.983,2020-03-07,2,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-01-22,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-01-23,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-01-24,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-01-25,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-01-26,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-01-27,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-01-28,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-01-29,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-01-30,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-01-31,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-02-01,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-02-02,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-02-03,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-02-04,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-02-05,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-02-06,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-02-07,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-02-08,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-02-09,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-02-10,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-02-11,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-02-12,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-02-13,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-02-14,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-02-15,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-02-16,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-02-17,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-02-18,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-02-19,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-02-20,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-02-21,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-02-22,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-02-23,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-02-24,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-02-25,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-02-26,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-02-27,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-02-28,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-02-29,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-03-01,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-03-02,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-03-03,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-03-04,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-03-05,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-03-06,0,0,0
+"Saratoga County, NY",US,43.0324,-73.936,2020-03-07,2,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-01-22,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-01-23,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-01-24,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-01-25,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-01-26,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-01-27,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-01-28,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-01-29,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-01-30,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-01-31,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-02-01,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-02-02,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-02-03,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-02-04,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-02-05,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-02-06,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-02-07,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-02-08,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-02-09,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-02-10,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-02-11,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-02-12,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-02-13,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-02-14,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-02-15,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-02-16,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-02-17,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-02-18,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-02-19,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-02-20,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-02-21,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-02-22,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-02-23,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-02-24,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-02-25,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-02-26,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-02-27,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-02-28,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-02-29,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-03-01,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-03-02,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-03-03,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-03-04,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-03-05,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-03-06,0,0,0
+"Edmonton, Alberta",Canada,53.5461,-113.4938,2020-03-07,1,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-01-22,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-01-23,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-01-24,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-01-25,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-01-26,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-01-27,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-01-28,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-01-29,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-01-30,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-01-31,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-02-01,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-02-02,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-02-03,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-02-04,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-02-05,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-02-06,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-02-07,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-02-08,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-02-09,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-02-10,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-02-11,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-02-12,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-02-13,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-02-14,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-02-15,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-02-16,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-02-17,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-02-18,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-02-19,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-02-20,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-02-21,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-02-22,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-02-23,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-02-24,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-02-25,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-02-26,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-02-27,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-02-28,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-02-29,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-03-01,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-03-02,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-03-03,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-03-04,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-03-05,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-03-06,0,0,0
+"Charleston County, SC",US,32.7957,-79.7848,2020-03-07,1,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-01-22,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-01-23,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-01-24,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-01-25,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-01-26,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-01-27,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-01-28,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-01-29,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-01-30,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-01-31,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-02-01,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-02-02,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-02-03,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-02-04,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-02-05,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-02-06,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-02-07,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-02-08,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-02-09,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-02-10,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-02-11,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-02-12,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-02-13,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-02-14,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-02-15,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-02-16,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-02-17,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-02-18,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-02-19,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-02-20,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-02-21,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-02-22,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-02-23,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-02-24,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-02-25,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-02-26,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-02-27,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-02-28,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-02-29,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-03-01,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-03-02,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-03-03,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-03-04,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-03-05,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-03-06,0,0,0
+"Clark County, WA",US,45.7466,-122.5194,2020-03-07,1,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-01-22,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-01-23,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-01-24,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-01-25,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-01-26,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-01-27,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-01-28,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-01-29,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-01-30,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-01-31,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-02-01,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-02-02,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-02-03,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-02-04,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-02-05,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-02-06,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-02-07,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-02-08,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-02-09,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-02-10,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-02-11,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-02-12,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-02-13,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-02-14,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-02-15,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-02-16,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-02-17,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-02-18,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-02-19,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-02-20,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-02-21,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-02-22,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-02-23,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-02-24,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-02-25,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-02-26,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-02-27,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-02-28,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-02-29,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-03-01,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-03-02,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-03-03,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-03-04,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-03-05,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-03-06,0,0,0
+"Cobb County, GA",US,33.8999,-84.5641,2020-03-07,1,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-01-22,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-01-23,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-01-24,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-01-25,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-01-26,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-01-27,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-01-28,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-01-29,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-01-30,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-01-31,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-02-01,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-02-02,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-02-03,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-02-04,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-02-05,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-02-06,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-02-07,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-02-08,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-02-09,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-02-10,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-02-11,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-02-12,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-02-13,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-02-14,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-02-15,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-02-16,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-02-17,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-02-18,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-02-19,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-02-20,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-02-21,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-02-22,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-02-23,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-02-24,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-02-25,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-02-26,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-02-27,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-02-28,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-02-29,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-03-01,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-03-02,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-03-03,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-03-04,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-03-05,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-03-06,0,0,0
+"Davis County, UT",US,40.9629,-112.0953,2020-03-07,1,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-01-22,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-01-23,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-01-24,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-01-25,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-01-26,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-01-27,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-01-28,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-01-29,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-01-30,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-01-31,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-02-01,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-02-02,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-02-03,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-02-04,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-02-05,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-02-06,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-02-07,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-02-08,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-02-09,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-02-10,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-02-11,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-02-12,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-02-13,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-02-14,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-02-15,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-02-16,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-02-17,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-02-18,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-02-19,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-02-20,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-02-21,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-02-22,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-02-23,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-02-24,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-02-25,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-02-26,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-02-27,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-02-28,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-02-29,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-03-01,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-03-02,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-03-03,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-03-04,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-03-05,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-03-06,0,0,0
+"El Paso County, CO",US,38.9108,-104.4723,2020-03-07,1,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-01-22,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-01-23,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-01-24,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-01-25,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-01-26,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-01-27,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-01-28,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-01-29,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-01-30,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-01-31,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-02-01,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-02-02,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-02-03,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-02-04,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-02-05,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-02-06,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-02-07,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-02-08,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-02-09,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-02-10,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-02-11,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-02-12,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-02-13,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-02-14,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-02-15,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-02-16,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-02-17,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-02-18,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-02-19,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-02-20,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-02-21,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-02-22,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-02-23,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-02-24,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-02-25,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-02-26,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-02-27,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-02-28,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-02-29,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-03-01,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-03-02,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-03-03,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-03-04,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-03-05,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-03-06,0,0,0
+"Honolulu County, HI",US,21.307,-157.8584,2020-03-07,1,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-01-22,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-01-23,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-01-24,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-01-25,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-01-26,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-01-27,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-01-28,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-01-29,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-01-30,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-01-31,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-02-01,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-02-02,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-02-03,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-02-04,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-02-05,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-02-06,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-02-07,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-02-08,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-02-09,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-02-10,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-02-11,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-02-12,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-02-13,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-02-14,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-02-15,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-02-16,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-02-17,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-02-18,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-02-19,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-02-20,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-02-21,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-02-22,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-02-23,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-02-24,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-02-25,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-02-26,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-02-27,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-02-28,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-02-29,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-03-01,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-03-02,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-03-03,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-03-04,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-03-05,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-03-06,0,0,0
+"Jackson County, OR",US,42.3345,-122.7647,2020-03-07,1,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-01-22,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-01-23,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-01-24,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-01-25,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-01-26,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-01-27,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-01-28,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-01-29,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-01-30,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-01-31,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-02-01,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-02-02,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-02-03,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-02-04,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-02-05,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-02-06,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-02-07,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-02-08,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-02-09,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-02-10,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-02-11,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-02-12,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-02-13,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-02-14,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-02-15,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-02-16,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-02-17,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-02-18,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-02-19,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-02-20,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-02-21,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-02-22,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-02-23,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-02-24,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-02-25,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-02-26,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-02-27,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-02-28,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-02-29,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-03-01,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-03-02,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-03-03,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-03-04,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-03-05,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-03-06,0,0,0
+"Jefferson County, WA",US,47.7425,-123.304,2020-03-07,1,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-01-22,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-01-23,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-01-24,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-01-25,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-01-26,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-01-27,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-01-28,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-01-29,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-01-30,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-01-31,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-02-01,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-02-02,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-02-03,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-02-04,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-02-05,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-02-06,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-02-07,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-02-08,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-02-09,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-02-10,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-02-11,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-02-12,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-02-13,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-02-14,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-02-15,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-02-16,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-02-17,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-02-18,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-02-19,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-02-20,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-02-21,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-02-22,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-02-23,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-02-24,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-02-25,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-02-26,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-02-27,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-02-28,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-02-29,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-03-01,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-03-02,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-03-03,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-03-04,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-03-05,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-03-06,0,0,0
+"Kershaw County, SC",US,34.3672,-80.5883,2020-03-07,1,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-01-22,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-01-23,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-01-24,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-01-25,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-01-26,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-01-27,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-01-28,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-01-29,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-01-30,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-01-31,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-02-01,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-02-02,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-02-03,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-02-04,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-02-05,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-02-06,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-02-07,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-02-08,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-02-09,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-02-10,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-02-11,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-02-12,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-02-13,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-02-14,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-02-15,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-02-16,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-02-17,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-02-18,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-02-19,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-02-20,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-02-21,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-02-22,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-02-23,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-02-24,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-02-25,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-02-26,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-02-27,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-02-28,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-02-29,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-03-01,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-03-02,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-03-03,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-03-04,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-03-05,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-03-06,0,0,0
+"Klamath County, OR",US,42.6953,-121.6142,2020-03-07,1,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-01-22,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-01-23,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-01-24,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-01-25,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-01-26,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-01-27,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-01-28,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-01-29,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-01-30,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-01-31,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-02-01,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-02-02,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-02-03,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-02-04,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-02-05,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-02-06,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-02-07,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-02-08,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-02-09,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-02-10,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-02-11,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-02-12,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-02-13,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-02-14,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-02-15,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-02-16,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-02-17,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-02-18,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-02-19,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-02-20,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-02-21,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-02-22,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-02-23,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-02-24,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-02-25,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-02-26,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-02-27,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-02-28,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-02-29,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-03-01,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-03-02,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-03-03,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-03-04,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-03-05,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-03-06,0,0,0
+"Madera County, CA",US,37.2519,-119.6963,2020-03-07,1,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-01-22,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-01-23,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-01-24,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-01-25,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-01-26,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-01-27,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-01-28,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-01-29,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-01-30,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-01-31,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-02-01,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-02-02,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-02-03,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-02-04,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-02-05,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-02-06,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-02-07,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-02-08,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-02-09,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-02-10,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-02-11,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-02-12,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-02-13,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-02-14,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-02-15,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-02-16,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-02-17,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-02-18,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-02-19,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-02-20,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-02-21,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-02-22,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-02-23,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-02-24,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-02-25,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-02-26,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-02-27,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-02-28,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-02-29,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-03-01,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-03-02,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-03-03,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-03-04,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-03-05,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-03-06,0,0,0
+"Pierce County, WA",US,47.0676,-122.1295,2020-03-07,1,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-01-22,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-01-23,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-01-24,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-01-25,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-01-26,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-01-27,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-01-28,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-01-29,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-01-30,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-01-31,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-02-01,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-02-02,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-02-03,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-02-04,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-02-05,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-02-06,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-02-07,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-02-08,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-02-09,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-02-10,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-02-11,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-02-12,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-02-13,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-02-14,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-02-15,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-02-16,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-02-17,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-02-18,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-02-19,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-02-20,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-02-21,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-02-22,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-02-23,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-02-24,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-02-25,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-02-26,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-02-27,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-02-28,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-02-29,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-03-01,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-03-02,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-03-03,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-03-04,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-03-05,0,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-03-06,1,0,0
+"Plymouth County, MA",US,42.1615,-70.7928,2020-03-07,1,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-01-22,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-01-23,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-01-24,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-01-25,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-01-26,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-01-27,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-01-28,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-01-29,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-01-30,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-01-31,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-02-01,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-02-02,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-02-03,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-02-04,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-02-05,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-02-06,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-02-07,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-02-08,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-02-09,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-02-10,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-02-11,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-02-12,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-02-13,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-02-14,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-02-15,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-02-16,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-02-17,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-02-18,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-02-19,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-02-20,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-02-21,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-02-22,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-02-23,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-02-24,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-02-25,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-02-26,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-02-27,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-02-28,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-02-29,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-03-01,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-03-02,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-03-03,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-03-04,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-03-05,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-03-06,0,0,0
+"Santa Cruz County, CA",US,36.9741,-122.0308,2020-03-07,1,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-01-22,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-01-23,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-01-24,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-01-25,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-01-26,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-01-27,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-01-28,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-01-29,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-01-30,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-01-31,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-02-01,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-02-02,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-02-03,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-02-04,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-02-05,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-02-06,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-02-07,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-02-08,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-02-09,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-02-10,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-02-11,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-02-12,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-02-13,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-02-14,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-02-15,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-02-16,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-02-17,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-02-18,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-02-19,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-02-20,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-02-21,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-02-22,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-02-23,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-02-24,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-02-25,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-02-26,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-02-27,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-02-28,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-02-29,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-03-01,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-03-02,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-03-03,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-03-04,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-03-05,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-03-06,0,0,0
+"Tulsa County, OK",US,36.1593,-95.941,2020-03-07,1,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-01-22,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-01-23,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-01-24,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-01-25,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-01-26,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-01-27,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-01-28,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-01-29,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-01-30,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-01-31,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-02-01,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-02-02,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-02-03,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-02-04,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-02-05,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-02-06,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-02-07,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-02-08,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-02-09,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-02-10,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-02-11,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-02-12,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-02-13,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-02-14,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-02-15,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-02-16,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-02-17,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-02-18,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-02-19,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-02-20,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-02-21,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-02-22,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-02-23,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-02-24,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-02-25,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-02-26,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-02-27,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-02-28,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-02-29,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-03-01,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-03-02,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-03-03,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-03-04,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-03-05,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-03-06,0,0,0
+"Montgomery County, TX",US,30.3213,-95.4778,2020-03-07,0,0,0


### PR DESCRIPTION
I didn't have permissions to edit the repo. When uploading to datahub.io, it fails due to the `/` in the header names. I tried placing them in strings, like `'"Country/Region"'`, but the output always ended up like this, `"""Country/Region"""`, so I just went with `Country` and `Province`.