### PR TITLE
Update required python to 3.6.12

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Build the data and create local changes
       uses: actions/setup-python@v1
       with:
-        python-version: '3.6.11'
+        python-version: '3.6.12'
         architecture: x64
     - name: Install requirements
       run: |


### PR DESCRIPTION
There is no 3.6.11 any more. Maybe there should be just python 3.6? Or even python 3?